### PR TITLE
change installation from forge

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,11 @@ We **do not give any warranties** and **will not be liable for any loss** incurr
 To install with [**Foundry**](https://github.com/gakonst/foundry):
 
 ```sh
-forge install vectorized/solady
+git clone git@github.com:Vectorized/solady.git
+
+cd solady
+
+forge install
 ```
 
 To install with [**Hardhat**](https://github.com/nomiclabs/hardhat) or [**Truffle**](https://github.com/trufflesuite/truffle):


### PR DESCRIPTION
## Change the installation from forge

`forge install vectorized/solady`

gives this error

![Screenshot from 2022-07-31 08-25-29](https://user-images.githubusercontent.com/43033153/182008106-2b6c953e-6b4e-4aff-b2e6-0c320a51f3a6.png)
