### PR TITLE
✨ Add a two arg version of forceSafeTransferETH

### DIFF
--- a/src/utils/SafeTransferLib.sol
+++ b/src/utils/SafeTransferLib.sol
@@ -87,6 +87,19 @@ library SafeTransferLib {
             }
         }
     }
+    
+    /// @dev Force sends `amount` (in wei) ETH to `to`, with a gas stipend
+    /// equal to _GAS_STIPEND_NO_GRIEF. This gas stipend is a reasonable default
+    /// for 99% of cases and can be overriden with the three-argument version of this
+    /// function if necessary.
+    ///
+    /// If sending via the normal procedure fails, force sends the ETH by
+    /// creating a temporary contract which uses `SELFDESTRUCT` to force send the ETH.
+    ///
+    /// Reverts if the current contract has insufficient balance.
+    function forceSafeTransferETH(address to, uint256 amount) internal {
+        forceSafeTransferETH(to, amount, _GAS_STIPEND_NO_GRIEF);
+    }
 
     /// @dev Sends `amount` (in wei) ETH to `to`, with a `gasStipend`.
     /// The `gasStipend` can be set to a low enough value to prevent

--- a/src/utils/SafeTransferLib.sol
+++ b/src/utils/SafeTransferLib.sol
@@ -89,7 +89,7 @@ library SafeTransferLib {
     }
     
     /// @dev Force sends `amount` (in wei) ETH to `to`, with a gas stipend
-    /// equal to _GAS_STIPEND_NO_GRIEF. This gas stipend is a reasonable default
+    /// equal to `_GAS_STIPEND_NO_GRIEF`. This gas stipend is a reasonable default
     /// for 99% of cases and can be overriden with the three-argument version of this
     /// function if necessary.
     ///
@@ -98,7 +98,27 @@ library SafeTransferLib {
     ///
     /// Reverts if the current contract has insufficient balance.
     function forceSafeTransferETH(address to, uint256 amount) internal {
-        forceSafeTransferETH(to, amount, _GAS_STIPEND_NO_GRIEF);
+        // Manually inlined because the compiler doesn't inline functions with branches.
+        assembly {
+            // If insufficient balance, revert.
+            if lt(selfbalance(), amount) {
+                // Store the function selector of `ETHTransferFailed()`.
+                mstore(0x00, 0xb12d13eb)
+                // Revert with (offset, size).
+                revert(0x1c, 0x04)
+            }
+            // Transfer the ETH and check if it succeeded or not.
+            if iszero(call(_GAS_STIPEND_NO_GRIEF, to, amount, 0, 0, 0, 0)) {
+                mstore(0x00, to) // Store the address in scratch space.
+                mstore8(0x0b, 0x73) // Opcode `PUSH20`.
+                mstore8(0x20, 0xff) // Opcode `SELFDESTRUCT`.
+                // We can directly use `SELFDESTRUCT` in the contract creation.
+                // We don't check and revert upon failure here, just in case
+                // `SELFDESTRUCT`'s behavior is changed some day in the future.
+                // (If that ever happens, we will riot, and port the code to use WETH).
+                pop(create(amount, 0x0b, 0x16))
+            }
+        }
     }
 
     /// @dev Sends `amount` (in wei) ETH to `to`, with a `gasStipend`.


### PR DESCRIPTION
## Description

`_GAS_STIPEND_NO_GRIEF` is reasonable in so many cases that it would be nice to have a version of this function that didn't require people typing it out each time.

## Checklist

Ensure you completed **all of the steps** below before submitting your pull request:

- [x] Ran `forge snapshot`?
- [x] Ran `npm run lint`?
- [x] Ran `forge test`?

_Pull requests with an incomplete checklist will be thrown out._

<!--     Emoji Table:     -->
<!-- readme/docs       📝 -->
 new feature       ✨
<!-- refactor/cleanup  ♻️ -->
<!-- nit               🥢 -->
<!-- security fix      🔒 -->
<!-- optimization      ⚡️ -->
<!-- configuration     👷‍♂️ -->
<!-- events            🔊 -->
<!-- bug fix           🐞 -->
