### PR TITLE
🥢 Multicallable: Use `public` and `virtual`

### DIFF
--- a/src/utils/Multicallable.sol
+++ b/src/utils/Multicallable.sol
@@ -14,7 +14,7 @@ abstract contract Multicallable {
     /// and store the `abi.encode` formatted results of each `DELEGATECALL` into `results`.
     /// If any of the `DELEGATECALL`s reverts, the entire transaction is reverted,
     /// and the error is bubbled up.
-    function multicall(bytes[] calldata data) external payable returns (bytes[] memory) {
+    function multicall(bytes[] calldata data) public payable virtual returns (bytes[] memory) {
         assembly {
             mstore(0x00, 0x20)
             mstore(0x20, data.length) // Store `data.length` into `results`.

--- a/src/utils/Multicallable.sol
+++ b/src/utils/Multicallable.sol
@@ -14,7 +14,7 @@ abstract contract Multicallable {
     /// and store the `abi.encode` formatted results of each `DELEGATECALL` into `results`.
     /// If any of the `DELEGATECALL`s reverts, the entire transaction is reverted,
     /// and the error is bubbled up.
-    function multicall(bytes[] calldata data) public payable virtual returns (bytes[] memory) {
+    function multicall(bytes[] calldata data) external payable virtual returns (bytes[] memory) {
         assembly {
             mstore(0x00, 0x20)
             mstore(0x20, data.length) // Store `data.length` into `results`.


### PR DESCRIPTION
## Description

🥢 Use `public` and `virtual` to conform to other Solady abstract contract style and permit overrides.

This is based on review of Auth contracts style.

## Checklist

Ensure you completed **all of the steps** below before submitting your pull request:

- [x] Ran `forge fmt`?
- [x] Ran `forge snapshot`?
- [x] Ran `forge test`?

_Pull requests with an incomplete checklist will be thrown out._

<!--     Emoji Table:     -->
<!-- readme/docs       📝 -->
<!-- new feature       ✨ -->
<!-- refactor/cleanup  ♻️ -->
<!-- nit               🥢 -->
<!-- security fix      🔒 -->
<!-- optimization      ⚡️ -->
<!-- configuration     👷‍♂️ -->
<!-- events            🔊 -->
<!-- bug fix           🐞 -->
