### PR TITLE
Use custom error in ERC2981.sol

### DIFF
--- a/src/tokens/ERC2981.sol
+++ b/src/tokens/ERC2981.sol
@@ -14,6 +14,9 @@ abstract contract ERC2981 {
 
     /// @dev The royalty receiver cannot be the zero address.
     error RoyaltyReceiverIsZeroAddress();
+    
+    /// @dev The Fee Denominator cannot be zero.
+    error FeeDenominatorIsZero();
 
     /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
     /*                          STORAGE                           */
@@ -42,7 +45,14 @@ abstract contract ERC2981 {
 
     /// @dev Checks that `_feeDenominator` is non-zero.
     constructor() {
-        require(_feeDenominator() != 0, "Fee denominator cannot be zero.");
+        uint256 feeDenominator = _feeDenominator();
+        /// @solidity memory-safe-assembly
+        assembly {
+            if iszero(feeDenominator) {
+                mstore(0x00, 0x4ece301a) // `FeeDenominatorIsZero()`.
+                revert(0x1c, 0x04)
+            }
+        }
     }
 
     /// @dev Returns the denominator for the royalty amount.


### PR DESCRIPTION
Amazing library! So nice to not have to worry about the "layout" garbage for storage. There must be a way to make your storage approach used by more people!

I'd be shocked if there wasn't a reason for the require + string thing, but just in case there isn't, I thought I'd get this in there. Note: I do not know assembly so DYOR.

Also I got nervous for upgradeable contracts when I saw the constructor() but looking now I think it's good / harmless.

Honestly if it's any more performant you could consider just hardcoding 10000 as a constant. What kind of sick freak uses a number that's not 10000?