### PR TITLE
♻️ In ERC4337.sol, update validateUserOp visibility to 'external'

### DIFF
--- a/src/accounts/ERC4337.sol
+++ b/src/accounts/ERC4337.sol
@@ -81,7 +81,7 @@ abstract contract ERC4337 is Ownable, UUPSUpgradeable, Receiver, ERC1271 {
         bytes32 userOpHash,
         uint256 missingAccountFunds
     )
-        public
+        external
         payable
         virtual
         onlyEntryPoint


### PR DESCRIPTION
## Description

According to the [ERC-4337 spec](https://eips.ethereum.org/EIPS/eip-4337#definitions), the function visibility for validateUserOp should be external rather than public. Although this is probably the world's most annoying PR, the change will help implementations of ERC-4337 compliant smart wallet accounts that integrate custom logic in validateUserOp integrate solady, since those are using the 'external' visibility modifier instead of 'public', which creates a compiler error upon integration since Solidity does not support function overloading for external and public functions with the same name.

P.S. Thank you for all that you do with solady🫡

## Checklist

Ensure you completed **all of the steps** below before submitting your pull request:

- [x] Ran `forge fmt`?
- [x] Ran `forge snapshot`?
- [x] Ran `forge test`?

_Pull requests with an incomplete checklist will be thrown out._

<!--     Emoji Table:     -->
<!-- readme/docs       📝 -->
<!-- new feature       ✨ -->
<!-- refactor/cleanup  ♻️ -->
<!-- nit               🥢 -->
<!-- security fix      🔒 -->
<!-- optimization      ⚡️ -->
<!-- configuration     👷‍♂️ -->
<!-- events            🔊 -->
<!-- bug fix           🐞 -->
