### PR TITLE
🥢 Nit Comment in FixedMathPointLib

### DIFF
--- a/src/utils/FixedPointMathLib.sol
+++ b/src/utils/FixedPointMathLib.sol
@@ -200,7 +200,7 @@ library FixedPointMathLib {
     function expWad(int256 x) internal pure returns (int256 r) {
         unchecked {
             // When the result is less than 0.5 we return zero.
-            // This happens when `x <= floor(log(0.5e18) * 1e18) ≈ -42e18`.
+            // This happens when `x <= (log(1e-18) * 1e18) ~ -4.15e19`.
             if (x <= -41446531673892822313) return r;
 
             /// @solidity memory-safe-assembly


### PR DESCRIPTION
## Description

As title. The updated threshold (via https://github.com/Vectorized/solady/pull/757) can be calculated using `math.log(1e-18) * 1e18` in Python (with a small precision loss in the last 3 digits).

## Checklist

Ensure you completed **all of the steps** below before submitting your pull request:

- [x] Ran `forge fmt`?
- [x] Ran `forge snapshot`?
- [x] Ran `forge test`?