### PR TITLE
📝 Minor Correct On ERC721 Comment

### DIFF
--- a/src/tokens/ERC721.sol
+++ b/src/tokens/ERC721.sol
@@ -666,7 +666,7 @@ abstract contract ERC721 {
     /// - If `by` is not the zero address, `by` must be the owner
     ///   or an approved operator for the token owner.
     ///
-    /// Emits a {Transfer} event.
+    /// Emits a {Approval} event.
     function _approve(address by, address account, uint256 id) internal virtual {
         assembly {
             // Clear the upper 96 bits.


### PR DESCRIPTION
## Description

A minor change from `Emit {Transfer} event` to `Emit {Approval} event` for ERC721's `_approve(address,address,uint256)` comment.
Found that when comming across the contract.


## Checklist

Ensure you completed **all of the steps** below before submitting your pull request:

- [ ] Ran `forge fmt`?
- [ ] Ran `forge snapshot`?
- [ ] Ran `forge test`?

_Pull requests with an incomplete checklist will be thrown out._

<!--     Emoji Table:     -->
<!-- readme/docs       📝 -->
<!-- new feature       ✨ -->
<!-- refactor/cleanup  ♻️ -->
<!-- nit               🥢 -->
<!-- security fix      🔒 -->
<!-- optimization      ⚡️ -->
<!-- configuration     👷‍♂️ -->
<!-- events            🔊 -->
<!-- bug fix           🐞 -->
