### PR TITLE
🥢 Chore(natspec): correct the url for libsort

### DIFF
--- a/src/utils/LibSort.sol
+++ b/src/utils/LibSort.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.4;
 
 /// @notice Optimized sorts and operations for sorted arrays.
-/// @author Solady (https://github.com/vectorized/solady/blob/main/src/utils/Sort.sol)
+/// @author Solady (https://github.com/Vectorized/solady/blob/main/src/utils/LibSort.sol)
 library LibSort {
     /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
     /*                      INSERTION SORT                        */


### PR DESCRIPTION
point to the correct name of the contract, from `Sort` to `LibSort`

Maybe create a symlink file or empty contract that imports libsort for sort as well, though thats up to you m8