### PR TITLE
✨ CI now uses new solidity version 0.8.26

### DIFF
--- a/.github/workflows/ci-all-via-ir.yml
+++ b/.github/workflows/ci-all-via-ir.yml
@@ -46,6 +46,7 @@ jobs:
             forge test --use 0.8.17 --via-ir
           ) ||
           ( [ "${{ matrix.profile }}" = "via-ir-3" ] &&
+            forge test --use 0.8.26 --via-ir &&
             forge test --use 0.8.25 --via-ir &&
             forge test --use 0.8.24 --via-ir &&
             forge test --use 0.8.23 --via-ir &&

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,10 +34,10 @@ jobs:
       - name: Run Tests with ${{ matrix.profile }}
         run: >
           ( [ "${{ matrix.profile }}" = "post-cancun" ] &&
-            forge test --use 0.8.25 --evm-version "cancun"
+            forge test --use 0.8.26 --evm-version "cancun"
           ) ||
           ( [ "${{ matrix.profile }}" = "post-cancun-via-ir" ] &&
-            forge test --use 0.8.25 --evm-version "cancun" --via-ir
+            forge test --use 0.8.26 --evm-version "cancun" --via-ir
           ) ||
           ( [ "${{ matrix.profile }}" = "solc-past-versions-0" ] &&
             forge test --use 0.8.5 --fuzz-runs 16 &&
@@ -61,7 +61,8 @@ jobs:
             forge test --use 0.8.21 --fuzz-runs 16 &&
             forge test --use 0.8.22 --fuzz-runs 16 &&
             forge test --use 0.8.23 --fuzz-runs 16 &&
-            forge test --use 0.8.24 --fuzz-runs 16
+            forge test --use 0.8.24 --fuzz-runs 16 &&
+            forge test --use 0.8.25 --fuzz-runs 16
           ) ||
           ( [ "${{ matrix.profile }}" = "via-ir" ] &&
             forge test --via-ir

--- a/README.md
+++ b/README.md
@@ -143,5 +143,5 @@ This repository is inspired by or directly modified from many sources, primarily
 [ci-shield]: https://img.shields.io/github/actions/workflow/status/vectorized/solady/ci.yml?branch=main&label=build
 [ci-url]: https://github.com/vectorized/solady/actions/workflows/ci.yml
 
-[solidity-shield]: https://img.shields.io/badge/solidity-%3E=0.8.4%20%3C=0.8.25-aa6746
+[solidity-shield]: https://img.shields.io/badge/solidity-%3E=0.8.4%20%3C=0.8.26-aa6746
 [solidity-ci-url]: https://github.com/Vectorized/solady/actions/workflows/ci-all-via-ir.yml

--- a/foundry.toml
+++ b/foundry.toml
@@ -4,7 +4,7 @@
 
 # The Default Profile
 [profile.default]
-solc_version = "0.8.25"
+solc_version = "0.8.26"
 evm_version = "paris" # Cancun will be tested in the CI.
 auto_detect_solc = false
 optimizer = true


### PR DESCRIPTION
## Description

CI now checks solidity version 0.8.26
also updated the solidity badge in readme

## Checklist

- [x] Ran `forge fmt`?
- [x] Ran `forge snapshot`?
- [x] Ran `forge test`?

