### PR TITLE
🐞 Add underscore to encodeURIComponent skipped characters

### DIFF
--- a/src/utils/LibString.sol
+++ b/src/utils/LibString.sol
@@ -1078,8 +1078,8 @@ library LibString {
             for { let end := add(s, mload(s)) } iszero(eq(s, end)) {} {
                 s := add(s, 1)
                 let c := and(mload(s), 0xff)
-                // If not in `[0-9A-Z-a-z-.!~*'()]`.
-                if iszero(and(1, shr(c, 0x47fffffe07fffffe03ff678200000000))) {
+                // If not in `[0-9A-Z-a-z-_.!~*'()]`.
+                if iszero(and(1, shr(c, 0x47fffffe87fffffe03ff678200000000))) {
                     mstore8(o, 0x25) // '%'.
                     mstore8(add(o, 1), mload(and(shr(4, c), 15)))
                     mstore8(add(o, 2), mload(and(c, 15)))

--- a/test/LibString.t.sol
+++ b/test/LibString.t.sol
@@ -1103,9 +1103,10 @@ contract LibStringTest is SoladyTest {
         _testEncodeURIComponent("", "");
         _testEncodeURIComponent("a", "a");
         _testEncodeURIComponent("ab", "ab");
+        string memory encodeURIComponentSkippedCharacters =
+            "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_.!~*'()";
         _testEncodeURIComponent(
-            "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz123456789",
-            "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz123456789"
+            encodeURIComponentSkippedCharacters, encodeURIComponentSkippedCharacters
         );
         // All of these characters are encoded, they are reserved by URI standard
         _testEncodeURIComponent(";/?:@&=+$,# ", "%3B%2F%3F%3A%40%26%3D%2B%24%2C%23%20");
@@ -1145,12 +1146,12 @@ contract LibStringTest is SoladyTest {
         unchecked {
             for (uint256 i = 0; i < inputLength; i++) {
                 bytes1 b = input[i];
-
                 if (
                     (b >= 0x30 && b <= 0x39) // 0-9
                         || (b >= 0x41 && b <= 0x5a) // A-Z
                         || (b >= 0x61 && b <= 0x7a) // a-z
                         || b == 0x2D // -
+                        || b == 0x5F // '_'
                         || b == 0x2E // .
                         || b == 0x21 // !
                         || b == 0x7E // ~
@@ -1176,6 +1177,7 @@ contract LibStringTest is SoladyTest {
                         || (b >= 0x41 && b <= 0x5a) // A-Z
                         || (b >= 0x61 && b <= 0x7a) // a-z
                         || b == 0x2D // -
+                        || b == 0x5F // '_'
                         || b == 0x2E // .
                         || b == 0x21 // !
                         || b == 0x7E // ~


### PR DESCRIPTION
## Description

Not a big issue, as escaping underscores will still work tho.
Just not faithful to the JavaScript implementation.

## Checklist

Ensure you completed **all of the steps** below before submitting your pull request:

- [x] Ran `forge fmt`?
- [x] Ran `forge test`?

_Pull requests with an incomplete checklist will be thrown out._

<!--     Emoji Table:     -->
<!-- readme/docs       📝 -->
<!-- new feature       ✨ -->
<!-- refactor/cleanup  ♻️ -->
<!-- nit               🥢 -->
<!-- security fix      🔒 -->
<!-- optimization      ⚡️ -->
<!-- configuration     👷‍♂️ -->
<!-- events            🔊 -->
<!-- bug fix           🐞 -->
