### PR TITLE
🐞 Fix AddressSet

### DIFF
--- a/src/utils/g/EnumerableSetLib.sol
+++ b/src/utils/g/EnumerableSetLib.sol
@@ -282,10 +282,14 @@ library EnumerableSetLib {
                 let p := keccak256(0x00, 0x40)
                 if iszero(sload(p)) {
                     n := shr(1, n)
-                    sstore(add(rootSlot, n), shl(96, value))
-                    sstore(p, add(1, n))
-                    sstore(rootSlot, add(2, rootPacked))
                     result := 1
+                    sstore(p, add(1, n))
+                    if iszero(n) {
+                        sstore(rootSlot, or(3, shl(96, value)))
+                        break
+                    }
+                    sstore(add(rootSlot, n), shl(96, value))
+                    sstore(rootSlot, add(2, rootPacked))
                     break
                 }
                 break


### PR DESCRIPTION
## Description

When an address set goes from fully initialized to zero elements to having elements again, the packing logic will errorneously leave the previous value in it. 

## Checklist

Ensure you completed **all of the steps** below before submitting your pull request:

- [x] Ran `forge fmt`?
- [x] Ran `forge test`?

_Pull requests with an incomplete checklist will be thrown out._

<!--     Emoji Table:     -->
<!-- readme/docs       📝 -->
<!-- new feature       ✨ -->
<!-- refactor/cleanup  ♻️ -->
<!-- nit               🥢 -->
<!-- security fix      🔒 -->
<!-- optimization      ⚡️ -->
<!-- configuration     👷‍♂️ -->
<!-- events            🔊 -->
<!-- bug fix           🐞 -->
