### PR TITLE
♻️ Rename decode to tryDecode

### DIFF
--- a/src/utils/P256.sol
+++ b/src/utils/P256.sol
@@ -104,7 +104,7 @@ library P256 {
 
     /// @dev Helper function for `abi.decode(encoded, (bytes32, bytes32))`.
     /// If `encoded.length < 64`, `(x, y)` will be `(0, 0)`, which is an invalid point.
-    function decodePoint(bytes memory encoded) internal pure returns (bytes32 x, bytes32 y) {
+    function tryDecodePoint(bytes memory encoded) internal pure returns (bytes32 x, bytes32 y) {
         /// @solidity memory-safe-assembly
         assembly {
             let t := gt(mload(encoded), 0x3f)
@@ -115,7 +115,7 @@ library P256 {
 
     /// @dev Helper function for `abi.decode(encoded, (bytes32, bytes32))`.
     /// If `encoded.length < 64`, `(x, y)` will be `(0, 0)`, which is an invalid point.
-    function decodePointCalldata(bytes calldata encoded)
+    function tryDecodePointCalldata(bytes calldata encoded)
         internal
         pure
         returns (bytes32 x, bytes32 y)

--- a/test/P256.t.sol
+++ b/test/P256.t.sol
@@ -235,16 +235,16 @@ contract P256Test is P256VerifierEtcher {
         assertFalse(_verifyViaVerifier(bytes32(0), 1, 1, p - 1, 1));
     }
 
-    function testDecodePoint(bytes32 x, bytes32 y) public {
+    function testTryDecodePoint(bytes32 x, bytes32 y) public {
         bytes memory encoded = abi.encodePacked(x, y);
-        (bytes32 xDecoded, bytes32 yDecoded) = P256.decodePoint(encoded);
+        (bytes32 xDecoded, bytes32 yDecoded) = P256.tryDecodePoint(encoded);
         assertEq(xDecoded, x);
         assertEq(yDecoded, y);
-        this.decodePointCalldata(encoded, x, y);
+        this.tryDecodePointCalldata(encoded, x, y);
     }
 
-    function decodePointCalldata(bytes calldata encoded, bytes32 x, bytes32 y) public {
-        (bytes32 xDecoded, bytes32 yDecoded) = P256.decodePointCalldata(encoded);
+    function tryDecodePointCalldata(bytes calldata encoded, bytes32 x, bytes32 y) public {
+        (bytes32 xDecoded, bytes32 yDecoded) = P256.tryDecodePointCalldata(encoded);
         assertEq(xDecoded, x);
         assertEq(yDecoded, y);
     }


### PR DESCRIPTION
## Description

Cuz the stuff in `WebAuthn` are also named `tryDecode`.

The word `try` is intentionally included to signal that it is different from `abi.decode`, which will revert on invalid data.

## Checklist

Ensure you completed **all of the steps** below before submitting your pull request:

- [x] Ran `forge fmt`?
- [x] Ran `forge test`?

_Pull requests with an incomplete checklist will be thrown out._

<!--     Emoji Table:     -->
<!-- readme/docs       📝 -->
<!-- new feature       ✨ -->
<!-- refactor/cleanup  ♻️ -->
<!-- nit               🥢 -->
<!-- security fix      🔒 -->
<!-- optimization      ⚡️ -->
<!-- configuration     👷‍♂️ -->
<!-- events            🔊 -->
<!-- bug fix           🐞 -->
