### PR TITLE
♻️ Timelock fixes

### DIFF
--- a/src/accounts/Timelock.sol
+++ b/src/accounts/Timelock.sol
@@ -24,6 +24,11 @@ import {EnumerableRoles} from "../auth/EnumerableRoles.sol";
 ///   The optional `salt` allows for multiple proposals of the same effective payload.
 /// - The id of a proposal can be computed as:
 ///   `keccak256(abi.encode(mode, keccak256(executionData)))`.
+///
+/// Supported modes:
+/// - `bytes32(0x01000000000000000000...)`: does not support optional `opData`.
+/// - `bytes32(0x01000000000078210001...)`: supports optional `opData`.
+/// Where `opData` is `abi.encode(predecessor)` or `abi.encode(predecessor, salt)`.
 contract Timelock is ERC7821, EnumerableRoles {
     /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
     /*                         CONSTANTS                          */

--- a/src/accounts/Timelock.sol
+++ b/src/accounts/Timelock.sol
@@ -15,7 +15,7 @@ import {EnumerableRoles} from "../auth/EnumerableRoles.sol";
 /// - This implementation uses custom errors with arguments for easier debugging.
 /// - `executionData` can be encoded in three different ways:
 ///   1. `abi.encode(calls)`.
-///   2. `abi.encode(calls, abi.encode(predecessor)`.
+///   2. `abi.encode(calls, abi.encode(predecessor))`.
 ///   3. `abi.encode(calls, abi.encode(predecessor, salt))`.
 ///   Where `calls` is of type `(address,uint256,bytes)[]`.
 ///   `predecessor` is the id of the proposal that must be executed before.

--- a/src/accounts/Timelock.sol
+++ b/src/accounts/Timelock.sol
@@ -28,7 +28,10 @@ import {EnumerableRoles} from "../auth/EnumerableRoles.sol";
 /// Supported modes:
 /// - `bytes32(0x01000000000000000000...)`: does not support optional `opData`.
 /// - `bytes32(0x01000000000078210001...)`: supports optional `opData`.
-/// Where `opData` is `abi.encode(predecessor)` or `abi.encode(predecessor, salt)`.
+/// Where `opData` is `abi.encode(predecessor)` or `abi.encode(predecessor, salt)`,
+/// and `...` is the remaining 22 bytes which can be anything.
+/// For ease of mind, just use:
+/// `0x0100000000007821000100000000000000000000000000000000000000000000`.
 contract Timelock is ERC7821, EnumerableRoles {
     /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
     /*                         CONSTANTS                          */

--- a/src/accounts/Timelock.sol
+++ b/src/accounts/Timelock.sol
@@ -17,12 +17,11 @@ import {EnumerableRoles} from "../auth/EnumerableRoles.sol";
 ///   1. `abi.encode(calls)`.
 ///   2. `abi.encode(calls, abi.encode(predecessor))`.
 ///   3. `abi.encode(calls, abi.encode(predecessor, salt))`.
-///   Where `calls` is of type `(address,uint256,bytes)[]`.
-///   `predecessor` is the id of the proposal that must be executed before.
-///   If `predecessor` is `bytes32(0)`, it will be ignored
-///   (treated as if no predecessor requirements).
-///   The optional `salt` allows for multiple proposals of the same effective payload.
-/// - The id of a proposal can be computed as:
+/// - Where `calls` is of type `(address,uint256,bytes)[]`, and
+///   `predecessor` is the id of the proposal that is required to be already executed.
+/// - If `predecessor` is `bytes32(0)`, it will be ignored (treated as if not required).
+/// - The optional `salt` allows for multiple proposals representing the same payload.
+/// - The proposal id is given by:
 ///   `keccak256(abi.encode(mode, keccak256(executionData)))`.
 ///
 /// Supported modes:

--- a/src/accounts/Timelock.sol
+++ b/src/accounts/Timelock.sol
@@ -21,6 +21,7 @@ import {EnumerableRoles} from "../auth/EnumerableRoles.sol";
 ///   `predecessor` is the id of the proposal that must be executed before.
 ///   If `predecessor` is `bytes32(0)`, it will be ignored
 ///   (treated as if no predecessor requirements).
+///   The optional `salt` allows for multiple proposals of the same effective payload.
 /// - The id of a proposal can be computed as:
 ///   `keccak256(abi.encode(mode, keccak256(executionData)))`.
 contract Timelock is ERC7821, EnumerableRoles {
@@ -356,7 +357,7 @@ contract Timelock is ERC7821, EnumerableRoles {
             // Check if optional predecessor has been executed.
             if iszero(lt(opData.length, 0x20)) {
                 let b := calldataload(opData.offset) // Predecessor's id.
-                mstore(0x00, b)
+                mstore(0x00, b) // `_TIMELOCK_SLOT` is already at `0x09`.
                 if iszero(or(iszero(b), and(1, sload(keccak256(0x00, 0x29))))) {
                     mstore(0x00, 0x90a9a618) // `TimelockUnexecutedPredecessor(bytes32)`.
                     mstore(0x20, b)

--- a/test/Timelock.t.sol
+++ b/test/Timelock.t.sol
@@ -12,8 +12,8 @@ contract TimelockTest is SoladyTest {
         bytes data;
     }
 
-    event Proposed(bytes32 indexed id, bytes executionData, uint256 readyTimestamp);
-    event Executed(bytes32 indexed id, bytes executionData);
+    event Proposed(bytes32 indexed id, bytes32 mode, bytes executionData, uint256 readyTimestamp);
+    event Executed(bytes32 indexed id, bytes32 mode, bytes executionData);
     event Cancelled(bytes32 indexed id);
     event MinDelaySet(uint256 newMinDelay);
 
@@ -224,7 +224,7 @@ contract TimelockTest is SoladyTest {
 
         t.readyTimestamp = block.timestamp + _DEFAULT_MIN_DELAY;
         vm.expectEmit(true, true, true, true);
-        emit Proposed(t.id, t.executionData, t.readyTimestamp);
+        emit Proposed(t.id, _SUPPORTED_MODE, t.executionData, t.readyTimestamp);
         assertEq(timelock.propose(_SUPPORTED_MODE, t.executionData, _DEFAULT_MIN_DELAY), t.id);
 
         assertEq(uint8(timelock.operationState(t.id)), uint8(Timelock.OperationState.Waiting));
@@ -257,7 +257,7 @@ contract TimelockTest is SoladyTest {
         vm.expectEmit(true, true, true, true);
         emit MinDelaySet(newMinDelay);
         vm.expectEmit(true, true, true, true);
-        emit Executed(t.id, t.executionData);
+        emit Executed(t.id, _SUPPORTED_MODE, t.executionData);
         timelock.execute(_SUPPORTED_MODE, t.executionData);
         assertEq(timelock.minDelay(), newMinDelay);
         assertEq(uint8(timelock.operationState(t.id)), uint8(Timelock.OperationState.Done));


### PR DESCRIPTION
## Description

Changes:

- We have to ensure that `mode` is included in the `id`, otherwise someone can force timelock to execute without the `opData`, which will exclude the check for the `predecessor`. 

  The `id` is now defined as `keccak256(abi.encode(mode, keccak256(executionData)))`.

- Use a `keccak256(abi.encodePacked(id, bytes9(_TIMELOCK_SLOT)))` for the slot of `id`. Let's just left-curve it to sleep better. After all, this contract is not supposed to be called frequently.

- Add comments to describe the encoding of `executionData`.

## Checklist

Ensure you completed **all of the steps** below before submitting your pull request:

- [x] Ran `forge fmt`?
- [x] Ran `forge test`?

_Pull requests with an incomplete checklist will be thrown out._

<!--     Emoji Table:     -->
<!-- readme/docs       📝 -->
<!-- new feature       ✨ -->
<!-- refactor/cleanup  ♻️ -->
<!-- nit               🥢 -->
<!-- security fix      🔒 -->
<!-- optimization      ⚡️ -->
<!-- configuration     👷‍♂️ -->
<!-- events            🔊 -->
<!-- bug fix           🐞 -->
