### PR TITLE
♻️ LibTransient safe calldata copying

### DIFF
--- a/src/utils/LibTransient.sol
+++ b/src/utils/LibTransient.sol
@@ -638,7 +638,7 @@ library LibTransient {
     function setCalldata(TBytes storage ptr, bytes calldata value) internal {
         /// @solidity memory-safe-assembly
         assembly {
-            tstore(ptr.slot, calldataload(sub(value.offset, 0x04)))
+            tstore(ptr.slot, or(shl(224, value.length), shr(32, calldataload(value.offset))))
             if iszero(lt(value.length, 0x1d)) {
                 mstore(0x00, ptr.slot)
                 let e := add(value.offset, value.length)
@@ -660,7 +660,7 @@ library LibTransient {
         ptr = _compat(ptr);
         /// @solidity memory-safe-assembly
         assembly {
-            sstore(ptr.slot, calldataload(sub(value.offset, 0x04)))
+            sstore(ptr.slot, or(shl(224, value.length), shr(32, calldataload(value.offset))))
             if iszero(lt(value.length, 0x1d)) {
                 mstore(0x00, ptr.slot)
                 let e := add(value.offset, value.length)

--- a/src/utils/g/LibTransient.sol
+++ b/src/utils/g/LibTransient.sol
@@ -647,7 +647,7 @@ library LibTransient {
     function setCalldata(TBytes storage ptr, bytes calldata value) internal {
         /// @solidity memory-safe-assembly
         assembly {
-            tstore(ptr.slot, calldataload(sub(value.offset, 0x04)))
+            tstore(ptr.slot, or(shl(224, value.length), shr(32, calldataload(value.offset))))
             if iszero(lt(value.length, 0x1d)) {
                 mstore(0x00, ptr.slot)
                 let e := add(value.offset, value.length)
@@ -669,7 +669,7 @@ library LibTransient {
         ptr = _compat(ptr);
         /// @solidity memory-safe-assembly
         assembly {
-            sstore(ptr.slot, calldataload(sub(value.offset, 0x04)))
+            sstore(ptr.slot, or(shl(224, value.length), shr(32, calldataload(value.offset))))
             if iszero(lt(value.length, 0x1d)) {
                 mstore(0x00, ptr.slot)
                 let e := add(value.offset, value.length)


### PR DESCRIPTION
## Description

Use safe alternative for packing length and first 28 bytes.

This is actually required, cuz calldata slicing in plain Solidity will return slices that may not have the length immediately before the data.

## Checklist

Ensure you completed **all of the steps** below before submitting your pull request:

- [x] Ran `forge fmt`?
- [x] Ran `forge test`?

_Pull requests with an incomplete checklist will be thrown out._

<!--     Emoji Table:     -->
<!-- readme/docs       📝 -->
<!-- new feature       ✨ -->
<!-- refactor/cleanup  ♻️ -->
<!-- nit               🥢 -->
<!-- security fix      🔒 -->
<!-- optimization      ⚡️ -->
<!-- configuration     👷‍♂️ -->
<!-- events            🔊 -->
<!-- bug fix           🐞 -->
