### PR TITLE
🥢 Also re-use return value in `at(AddressSet,uint256)`

### DIFF
--- a/src/utils/EnumerableSetLib.sol
+++ b/src/utils/EnumerableSetLib.sol
@@ -614,10 +614,10 @@ library EnumerableSetLib {
 
     /// @dev Returns the element at index `i` in the set. Reverts if `i` is out-of-bounds.
     function at(AddressSet storage set, uint256 i) internal view returns (address result) {
-        bytes32 rootSlot = _rootSlot(set);
+        result = _rootSlot(set);
         /// @solidity memory-safe-assembly
         assembly {
-            result := shr(96, sload(add(rootSlot, i)))
+            result := shr(96, sload(add(result, i)))
             result := mul(result, iszero(eq(result, _ZERO_SENTINEL)))
         }
         if (i >= length(set)) revert IndexOutOfBounds();


### PR DESCRIPTION
## Description

In EnumerableSetLib the function `at(Bytes32Set,uint256)` re-uses the return value. But `at(AddressSet,uint256)` doesn't. If there isn't any specific reason not to, both functions should do the same.

## Checklist

Ensure you completed **all of the steps** below before submitting your pull request:

- [x] Ran `forge fmt`?
- [x] Ran `forge test`?
