### PR TITLE
🥢 Update ERC20Votes clock to virtual so it can allow for timestamp clock_mode

### DIFF
--- a/src/tokens/ERC20Votes.sol
+++ b/src/tokens/ERC20Votes.sol
@@ -96,7 +96,7 @@ abstract contract ERC20Votes is ERC20 {
         return "mode=blocknumber&from=default";
     }
 
-    /// @dev Retusn the current clock.
+    /// @dev Returns the current clock.
     function clock() public view virtual returns (uint48 result) {
         /// @solidity memory-safe-assembly
         assembly {

--- a/src/tokens/ERC20Votes.sol
+++ b/src/tokens/ERC20Votes.sol
@@ -97,7 +97,7 @@ abstract contract ERC20Votes is ERC20 {
     }
 
     /// @dev Retusn the current clock.
-    function clock() public view returns (uint48 result) {
+    function clock() public view virtual returns (uint48 result) {
         /// @solidity memory-safe-assembly
         assembly {
             result := number()


### PR DESCRIPTION
CLOCK_MODE() is virtual, we need clock() to be virtual as well otherwise there's an issue with using mode=timestamp while returning a block.number.

## Description

We need clock() to be virtual in case users want timestamp based clock_mode

## Checklist

Ensure you completed **all of the steps** below before submitting your pull request:

- [X] Ran `forge fmt`?
- [X] Ran `forge test`?

_Pull requests with an incomplete checklist will be thrown out._

<!--     Emoji Table:     -->
<!-- readme/docs       📝 -->
<!-- new feature       ✨ -->
<!-- refactor/cleanup  ♻️ -->
<!-- nit               🥢 -->
<!-- security fix      🔒 -->
<!-- optimization      ⚡️ -->
<!-- configuration     👷‍♂️ -->
<!-- events            🔊 -->
<!-- bug fix           🐞 -->
