### PR TITLE
♻️  Fix SignatureCheckerLib values

### DIFF
--- a/src/utils/SignatureCheckerLib.sol
+++ b/src/utils/SignatureCheckerLib.sol
@@ -153,8 +153,8 @@ library SignatureCheckerLib {
                 mstore(d, 0x40) // The offset of the `signature` in the calldata.
                 mstore(add(m, 0x44), 65) // Length of the signature.
                 mstore(add(m, 0x64), r) // `r`.
-                mstore(add(m, 0x84), mload(0x60)) // `s`.
-                mstore8(add(m, 0xa4), mload(0x20)) // `v`.
+                mstore(add(m, 0x84), shr(1, shl(1, vs))) // `s`.
+                mstore8(add(m, 0xa4), add(shr(255, vs), 27)) // `v`.
                 isValid := staticcall(gas(), signer, m, 0xa5, d, 0x20)
                 isValid := and(eq(mload(d), f), isValid)
                 break

--- a/test/SignatureCheckerLib.t.sol
+++ b/test/SignatureCheckerLib.t.sol
@@ -61,6 +61,7 @@ contract SignatureCheckerLibTest is SoladyTest {
         bytes32 hash = TEST_SIGNED_MESSAGE_HASH;
         bytes memory signature = SIGNATURE;
         _checkSignature(true, signer, hash, signature, true);
+        _checkSignature(false, signer, hash, signature, true);
         vm.etch(signer, "");
         _checkSignature(false, signer, hash, signature, false);
     }


### PR DESCRIPTION
## Description

Fixes the ERC1271 case for the `isValidSignatureNow()` function that takes `bytes32 vs` as input, since it no longer shares the memory layout from the `ecrecover()` case. Also update one of the testcases to test this behavior.

## Checklist

Ensure you completed **all of the steps** below before submitting your pull request:

- [X] Ran `forge fmt`?
- [X] Ran `forge test`?

_Pull requests with an incomplete checklist will be thrown out._