### PR TITLE
♻️ Initializable ensure _initializableSlot cannot be zero

### DIFF
--- a/src/utils/Initializable.sol
+++ b/src/utils/Initializable.sol
@@ -40,10 +40,20 @@ abstract contract Initializable {
         0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffbf601132;
 
     /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
+    /*                        CONSTRUCTOR                         */
+    /*.•°:°.´+˚.*°.˚:*.´•*.+°.•°:´*.´•*.•°.•°:°.´:•˚°.*°.˚:*.´+°.•*/
+
+    constructor() {
+        // Construction time check to ensure that `_initializableSlot()` is not
+        // overriden to zero. Will be optimized away if there is no revert.
+        require(_initializableSlot() != bytes32(0));
+    }
+
+    /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
     /*                         OPERATIONS                         */
     /*.•°:°.´+˚.*°.˚:*.´•*.+°.•°:´*.´•*.•°.•°:°.´:•˚°.*°.˚:*.´+°.•*/
 
-    /// @dev Override to return a custom storage slot if required.
+    /// @dev Override to return a non-zero custom storage slot if required.
     function _initializableSlot() internal pure virtual returns (bytes32) {
         return _INITIALIZABLE_SLOT;
     }

--- a/src/utils/Initializable.sol
+++ b/src/utils/Initializable.sol
@@ -45,7 +45,7 @@ abstract contract Initializable {
 
     constructor() {
         // Construction time check to ensure that `_initializableSlot()` is not
-        // overriden to zero. Will be optimized away if there is no revert.
+        // overridden to zero. Will be optimized away if there is no revert.
         require(_initializableSlot() != bytes32(0));
     }
 


### PR DESCRIPTION
## Description

As a zero value can cause a logical error in the `initialize` modifier.

## Checklist

Ensure you completed **all of the steps** below before submitting your pull request:

- [x] Ran `forge fmt`?
- [x] Ran `forge test`?

_Pull requests with an incomplete checklist will be thrown out._

<!--     Emoji Table:     -->
<!-- readme/docs       📝 -->
<!-- new feature       ✨ -->
<!-- refactor/cleanup  ♻️ -->
<!-- nit               🥢 -->
<!-- security fix      🔒 -->
<!-- optimization      ⚡️ -->
<!-- configuration     👷‍♂️ -->
<!-- events            🔊 -->
<!-- bug fix           🐞 -->
