### PR TITLE
⚡️ Optimize argsOnClone

### DIFF
--- a/src/utils/LibClone.sol
+++ b/src/utils/LibClone.sol
@@ -670,11 +670,7 @@ library LibClone {
         assembly {
             args := mload(0x40)
             // If the extcodesize is too small,
-            // `n` will be a big number that is around 0xffffffffff.
             let n := and(0xffffffffff, sub(extcodesize(instance), 0x2d))
-            // We shall subtract `start` from `n`, so as to copy less bytes.
-            // The and `0xffffff` ensures that no underflow can happen.
-            // If start is greater than `0xffffff`, we will still copy `n`. Doesn't change the logic.
             let l := sub(n, and(0xffffff, mul(lt(start, n), start)))
             extcodecopy(instance, args, add(start, 0x0d), add(l, 0x40))
             mstore(args, mul(sub(n, start), lt(start, n))) // Store the length.
@@ -1151,7 +1147,7 @@ library LibClone {
             args := mload(0x40)
             let n := and(0xffffffffff, sub(extcodesize(instance), 0x3d))
             let l := sub(n, and(0xffffff, mul(lt(start, n), start)))
-            extcodecopy(instance, add(args, 0x20), add(start, 0x3d), add(l, 0x20))
+            extcodecopy(instance, args, add(start, 0x1d), add(l, 0x40))
             mstore(args, mul(sub(n, start), lt(start, n))) // Store the length.
             mstore(0x40, add(args, add(0x40, mload(args)))) // Allocate memory.
         }
@@ -1652,7 +1648,7 @@ library LibClone {
             args := mload(0x40)
             let n := and(0xffffffffff, sub(extcodesize(instance), 0x52))
             let l := sub(n, and(0xffffff, mul(lt(start, n), start)))
-            extcodecopy(instance, add(args, 0x20), add(start, 0x52), add(l, 0x20))
+            extcodecopy(instance, args, add(start, 0x32), add(l, 0x40))
             mstore(args, mul(sub(n, start), lt(start, n))) // Store the length.
             mstore(0x40, add(mload(args), add(args, 0x40))) // Allocate memory.
         }
@@ -2248,7 +2244,7 @@ library LibClone {
             args := mload(0x40)
             let n := and(0xffffffffff, sub(extcodesize(instance), 0x52))
             let l := sub(n, and(0xffffff, mul(lt(start, n), start)))
-            extcodecopy(instance, add(args, 0x20), add(start, 0x52), add(l, 0x20))
+            extcodecopy(instance, args, add(start, 0x32), add(l, 0x40))
             mstore(args, mul(sub(n, start), lt(start, n))) // Store the length.
             mstore(0x40, add(args, add(0x40, mload(args)))) // Allocate memory.
         }
@@ -2751,7 +2747,7 @@ library LibClone {
             args := mload(0x40)
             let n := and(0xffffffffff, sub(extcodesize(instance), 0x57))
             let l := sub(n, and(0xffffff, mul(lt(start, n), start)))
-            extcodecopy(instance, add(args, 0x20), add(start, 0x57), add(l, 0x20))
+            extcodecopy(instance, args, add(start, 0x37), add(l, 0x40))
             mstore(args, mul(sub(n, start), lt(start, n))) // Store the length.
             mstore(0x40, add(args, add(0x40, mload(args)))) // Allocate memory.
         }

--- a/src/utils/LibClone.sol
+++ b/src/utils/LibClone.sol
@@ -669,9 +669,14 @@ library LibClone {
         /// @solidity memory-safe-assembly
         assembly {
             args := mload(0x40)
+            // If the extcodesize is too small,
+            // `n` will be a big number that is around 0xffffffffff.
             let n := and(0xffffffffff, sub(extcodesize(instance), 0x2d))
+            // We shall subtract `start` from `n`, so as to copy less bytes.
+            // The and `0xffffff` ensures that no underflow can happen.
+            // If start is greater than `0xffffff`, we will still copy `n`. Doesn't change the logic.
             let l := sub(n, and(0xffffff, mul(lt(start, n), start)))
-            extcodecopy(instance, add(args, 0x20), add(start, 0x2d), add(l, 0x20))
+            extcodecopy(instance, args, add(start, 0x0d), add(l, 0x40))
             mstore(args, mul(sub(n, start), lt(start, n))) // Store the length.
             mstore(0x40, add(args, add(0x40, mload(args)))) // Allocate memory.
         }

--- a/src/utils/LibClone.sol
+++ b/src/utils/LibClone.sol
@@ -669,7 +669,6 @@ library LibClone {
         /// @solidity memory-safe-assembly
         assembly {
             args := mload(0x40)
-            // If the extcodesize is too small,
             let n := and(0xffffffffff, sub(extcodesize(instance), 0x2d))
             let l := sub(n, and(0xffffff, mul(lt(start, n), start)))
             extcodecopy(instance, args, add(start, 0x0d), add(l, 0x40))


### PR DESCRIPTION
## Description

```solidity
// If the extcodesize is too small, 
// `n` will be a big number that is around 0xffffffffff. 
// This will force the `extcodecopy` to OOG.
let n := and(0xffffffffff, sub(extcodesize(instance), 0x2d))
// We shall subtract `start` from `n`, so as to copy less bytes.
// The and `0xffffff` ensures that no underflow can happen.
// We don't want underflows to mess with our prep on `n`.
// If start is greater than `0xffffff`, we will still copy `n`. 
// Doesn't change the logic.
let l := sub(n, and(0xffffff, mul(lt(start, n), start)))
```

## Checklist

Ensure you completed **all of the steps** below before submitting your pull request:

- [x] Ran `forge fmt`?
- [x] Ran `forge test`?

_Pull requests with an incomplete checklist will be thrown out._

<!--     Emoji Table:     -->
<!-- readme/docs       📝 -->
<!-- new feature       ✨ -->
<!-- refactor/cleanup  ♻️ -->
<!-- nit               🥢 -->
<!-- security fix      🔒 -->
<!-- optimization      ⚡️ -->
<!-- configuration     👷‍♂️ -->
<!-- events            🔊 -->
<!-- bug fix           🐞 -->
