### PR TITLE
⚡️ Optimize upgradeCall

### DIFF
--- a/src/utils/UUPSUpgradeable.sol
+++ b/src/utils/UUPSUpgradeable.sol
@@ -84,11 +84,10 @@ abstract contract UUPSUpgradeable {
         /// @solidity memory-safe-assembly
         assembly {
             newImplementation := shr(96, shl(96, newImplementation)) // Clears upper 96 bits.
-            mstore(0x01, 0x52d1902d) // `proxiableUUID()`.
+            mstore(0x00, 0x52d1902d) // `proxiableUUID()`.
             let s := _ERC1967_IMPLEMENTATION_SLOT
             // Check if `newImplementation` implements `proxiableUUID` correctly.
-            let t := staticcall(gas(), newImplementation, 0x1d, 0x04, 0x00, 0x20)
-            if iszero(and(eq(mload(0x00), s), t)) {
+            if iszero(eq(mload(staticcall(gas(), newImplementation, 0x1c, 0x04, 0x01, 0x20)), s)) {
                 mstore(0x01, 0x55299b49) // `UpgradeFailed()`.
                 revert(0x1d, 0x04)
             }

--- a/src/utils/UUPSUpgradeable.sol
+++ b/src/utils/UUPSUpgradeable.sol
@@ -84,10 +84,11 @@ abstract contract UUPSUpgradeable {
         /// @solidity memory-safe-assembly
         assembly {
             newImplementation := shr(96, shl(96, newImplementation)) // Clears upper 96 bits.
-            mstore(0x00, 0x52d1902d) // `proxiableUUID()`.
+            mstore(0x00, returndatasize())
+            mstore(0x01, 0x52d1902d) // `proxiableUUID()`.
             let s := _ERC1967_IMPLEMENTATION_SLOT
             // Check if `newImplementation` implements `proxiableUUID` correctly.
-            if iszero(eq(mload(staticcall(gas(), newImplementation, 0x1c, 0x04, 0x01, 0x20)), s)) {
+            if iszero(eq(mload(staticcall(gas(), newImplementation, 0x1d, 0x04, 0x01, 0x20)), s)) {
                 mstore(0x01, 0x55299b49) // `UpgradeFailed()`.
                 revert(0x1d, 0x04)
             }


### PR DESCRIPTION
## Description

Now if call reverts then it read from `0x00` can't possible to read magic number from revert data bcs 1st bytes is always zero. 

## Checklist

Ensure you completed **all of the steps** below before submitting your pull request:

- [x] Ran `forge fmt`?
- [x] Ran `forge test`?

_Pull requests with an incomplete checklist will be thrown out._

<!--     Emoji Table:     -->
<!-- readme/docs       📝 -->
<!-- new feature       ✨ -->
<!-- refactor/cleanup  ♻️ -->
<!-- nit               🥢 -->
<!-- security fix      🔒 -->
<!-- optimization      ⚡️ -->
<!-- configuration     👷‍♂️ -->
<!-- events            🔊 -->
<!-- bug fix           🐞 -->
