### PR TITLE
✨ Add commonPrefix

### DIFF
--- a/src/utils/LibBit.sol
+++ b/src/utils/LibBit.sol
@@ -117,6 +117,17 @@ library LibBit {
         }
     }
 
+    /// @dev Returns the common prefix of `x` and `y` in hex format.
+    function commonPrefix(uint256 x, uint256 y) internal pure returns (uint256 r) {
+        uint256 lz = clz(x ^ y);
+        assembly {
+            let nibbles := div(lz, 4)
+            // Since nibbles is always <= 64, there's no risk of underflow.
+            let bits := mul(sub(64, nibbles), 4)
+            r := shl(bits, shr(bits, x))
+        }
+    }
+
     /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
     /*                     BOOLEAN OPERATIONS                     */
     /*.•°:°.´+˚.*°.˚:*.´•*.+°.•°:´*.´•*.•°.•°:°.´:•˚°.*°.˚:*.´+°.•*/

--- a/test/LibBit.t.sol
+++ b/test/LibBit.t.sol
@@ -224,4 +224,17 @@ contract LibBitTest is SoladyTest {
             r := mload(0x00)
         }
     }
+
+    function testCommonPrefix() public {
+        assertEq(LibBit.commonPrefix(0x1, 0x2), 0);
+        assertEq(LibBit.commonPrefix(0x1234abc, 0x1234bbb), 0x1234000);
+        assertEq(LibBit.commonPrefix(0x1234abc, 0x1234abc), 0x1234abc);
+    }
+
+    function testCommonPrefix(uint256 x, uint8 p) public {
+        uint256 y = x ^ (1 << p);
+        uint256 l = 63 - p / 4;
+        uint256 r = l == 0 ? 0 : x & ~((1 << ((64 - l) * 4)) - 1);
+        assertEq(LibBit.commonPrefix(x, y), r);
+    }
 }


### PR DESCRIPTION
## Description

The `commonPrefix` function efficiently finds the common prefix (matching most significant bits) between two 256-bit numbers and returns it in hex format.

Potential Variations:
1. `commonBitPrefix` - Could return just the number of matching bits (similar to current implementation's internal use of `clz`)
2. `commonBytePrefix` - Could operate at byte granularity instead of nibbles (4 bits), which might be more useful for byte-oriented data like addresses or byte arrays

## Checklist

Ensure you completed **all of the steps** below before submitting your pull request:

- [x] Ran `forge fmt`?
- [x] Ran `forge test`?

_Pull requests with an incomplete checklist will be thrown out._

<!--     Emoji Table:     -->
<!-- readme/docs       📝 -->
<!-- new feature       ✨ -->
<!-- refactor/cleanup  ♻️ -->
<!-- nit               🥢 -->
<!-- security fix      🔒 -->
<!-- optimization      ⚡️ -->
<!-- configuration     👷‍♂️ -->
<!-- events            🔊 -->
<!-- bug fix           🐞 -->
