### PR TITLE
👷‍♂️ fix: build on Win fails due to transient skip

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -10,14 +10,14 @@ auto_detect_solc = false
 optimizer = true
 optimizer_runs = 1_000
 gas_limit = 100_000_000 # ETH is 30M, but we use a higher value.
-skip = ["/*Transient*", "*/ext/ithaca/*", "*/ext/zksync/*"]
+skip = ["*/*Transient*", "*/ext/ithaca/*", "*/ext/zksync/*"]
 fs_permissions = [{ access = "read", path = "./test/data"}]
 remappings = [
   "forge-std=test/utils/forge-std/"
 ]
 
 [profile.pre_global_structs]
-skip = ["*/g/*", "/*Transient*", "*/ext/ithaca/*", "*/ext/zksync/*"]
+skip = ["*/g/*", "*/*Transient*", "*/ext/ithaca/*", "*/ext/zksync/*"]
 
 [profile.post_cancun]
 evm_version = "cancun"


### PR DESCRIPTION
## Description

`forge build` fails on Windows with https://github.com/foundry-rs/foundry/actions/runs/13068792712/job/36465786880#step:12:70 (see https://github.com/foundry-rs/foundry/pull/9797). This happens due to `"/*Transient*"` not matched (unclear now why it is on non win, going to be followed up in foundry)
Fixed by changing `"/*Transient*"` to `"*/*Transient*"`

[Non related]: with latest nightly forge builds tests are failing with `call didn't revert at a lower depth than cheatcode call depth;` message, this happens due to changed behavior of `expectRevert` please consider https://book.getfoundry.sh/cheatcodes/expect-revert#description

## Checklist

Ensure you completed **all of the steps** below before submitting your pull request:

- [x] Ran `forge fmt`?
- [x] Ran `forge test`?

_Pull requests with an incomplete checklist will be thrown out._

<!--     Emoji Table:     -->
<!-- readme/docs       📝 -->
<!-- new feature       ✨ -->
<!-- refactor/cleanup  ♻️ -->
<!-- nit               🥢 -->
<!-- security fix      🔒 -->
<!-- optimization      ⚡️ -->
<!-- configuration     👷‍♂️ -->
<!-- events            🔊 -->
<!-- bug fix           🐞 -->
