### PR TITLE
♻️ More memory-safe annotations

### DIFF
--- a/prep/memory-safe-scan.js
+++ b/prep/memory-safe-scan.js
@@ -1,0 +1,29 @@
+#!/usr/bin/env node
+const { readSync, forEachWalkSync, hasAnyPathSequence } = require('./common.js');
+
+async function main() {
+  const pathSequencesToIgnore = ['g', 'ext', 'legacy'];
+
+  const loggedSrcPaths = [];
+  forEachWalkSync(['src'], srcPath => {
+    if (!srcPath.match(/\.sol$/i)) return;
+    if (hasAnyPathSequence(srcPath, pathSequencesToIgnore)) return;
+
+    const src = readSync(srcPath);
+    const assemblyTagRe = /(\/\/\/\s*?@solidity\s*?memory-safe-assembly\s+?)?assembly\s*?(\(.*?\))?\{/gm;
+    for (let m = null; (m = assemblyTagRe.exec(src)) !== null; ) {
+      if ((m[0] + '').indexOf('memory-safe') === -1) {
+        if (loggedSrcPaths.indexOf(srcPath) === -1) {
+          loggedSrcPaths.push(srcPath);
+          console.log(srcPath + ':');
+        }
+        console.log('  line:', src.slice(0, m.index).split(/\n/).length);
+      }
+    }
+  });
+};
+
+main().catch(e => {
+  console.error(e);
+  process.exit(1);
+});

--- a/prep/memory-safe-scan.js
+++ b/prep/memory-safe-scan.js
@@ -2,7 +2,7 @@
 const { readSync, forEachWalkSync, hasAnyPathSequence } = require('./common.js');
 
 async function main() {
-  const pathSequencesToIgnore = ['g', 'ext', 'legacy'];
+  const pathSequencesToIgnore = ['g', 'legacy'];
 
   const loggedSrcPaths = [];
   forEachWalkSync(['src'], srcPath => {

--- a/src/accounts/EIP7702Proxy.sol
+++ b/src/accounts/EIP7702Proxy.sol
@@ -38,7 +38,8 @@ contract EIP7702Proxy {
     /*.•°:°.´+˚.*°.˚:*.´•*.+°.•°:´*.´•*.•°.•°:°.´:•˚°.*°.˚:*.´+°.•*/
 
     constructor(address initialImplementation, address initialAdmin) payable {
-        assembly ("memory-safe") {
+        /// @solidity memory-safe-assembly
+        assembly {
             sstore(_ERC1967_IMPLEMENTATION_SLOT, shr(96, shl(96, initialImplementation)))
             sstore(_ERC1967_ADMIN_SLOT, shr(96, shl(96, initialAdmin)))
         }
@@ -50,6 +51,7 @@ contract EIP7702Proxy {
 
     fallback() external payable virtual {
         uint256 s = __self;
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x40, returndatasize()) // Optimization trick to change `6040608052` into `3d604052`.
             // Workflow for calling on the proxy itself.

--- a/src/accounts/EIP7702Proxy.sol
+++ b/src/accounts/EIP7702Proxy.sol
@@ -38,7 +38,7 @@ contract EIP7702Proxy {
     /*.•°:°.´+˚.*°.˚:*.´•*.+°.•°:´*.´•*.•°.•°:°.´:•˚°.*°.˚:*.´+°.•*/
 
     constructor(address initialImplementation, address initialAdmin) payable {
-        assembly {
+        assembly ("memory-safe") {
             sstore(_ERC1967_IMPLEMENTATION_SLOT, shr(96, shl(96, initialImplementation)))
             sstore(_ERC1967_ADMIN_SLOT, shr(96, shl(96, initialAdmin)))
         }

--- a/src/accounts/ERC6551Proxy.sol
+++ b/src/accounts/ERC6551Proxy.sol
@@ -46,12 +46,14 @@ contract ERC6551Proxy {
 
     fallback() external payable virtual {
         bytes32 implementation;
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x40, returndatasize()) // Optimization trick to change `6040608052` into `3d604052`.
             implementation := sload(_ERC1967_IMPLEMENTATION_SLOT)
         }
         if (implementation == bytes32(0)) {
             implementation = _defaultImplementation;
+            /// @solidity memory-safe-assembly
             assembly {
                 // Only initialize if the calldatasize is zero, so that staticcalls to
                 // functions (which will have 4-byte function selectors) won't revert.
@@ -60,6 +62,7 @@ contract ERC6551Proxy {
                 if iszero(calldatasize()) { sstore(_ERC1967_IMPLEMENTATION_SLOT, implementation) }
             }
         }
+        /// @solidity memory-safe-assembly
         assembly {
             calldatacopy(returndatasize(), returndatasize(), calldatasize())
             // forgefmt: disable-next-item

--- a/src/tokens/ERC721.sol
+++ b/src/tokens/ERC721.sol
@@ -668,6 +668,7 @@ abstract contract ERC721 {
     ///
     /// Emits a {Approval} event.
     function _approve(address by, address account, uint256 id) internal virtual {
+        /// @solidity memory-safe-assembly
         assembly {
             // Clear the upper 96 bits.
             let bitmaskAddress := shr(96, not(0))

--- a/src/tokens/ext/zksync/ERC721.sol
+++ b/src/tokens/ext/zksync/ERC721.sol
@@ -666,6 +666,7 @@ abstract contract ERC721 {
     ///
     /// Emits a {Approval} event.
     function _approve(address by, address account, uint256 id) internal virtual {
+        /// @solidity memory-safe-assembly
         assembly {
             // Clear the upper 96 bits.
             let bitmaskAddress := shr(96, not(0))

--- a/src/utils/DynamicArrayLib.sol
+++ b/src/utils/DynamicArrayLib.sol
@@ -347,6 +347,7 @@ library DynamicArrayLib {
 
     /// @dev Directly returns `a` without copying.
     function directReturn(uint256[] memory a) internal pure {
+        /// @solidity memory-safe-assembly
         assembly {
             let retStart := sub(a, 0x20)
             mstore(retStart, 0x20)
@@ -988,6 +989,7 @@ library DynamicArrayLib {
 
     /// @dev Directly returns `a` without copying.
     function directReturn(DynamicArray memory a) internal pure {
+        /// @solidity memory-safe-assembly
         assembly {
             let arrData := mload(a)
             let retStart := sub(arrData, 0x20)

--- a/src/utils/ECDSA.sol
+++ b/src/utils/ECDSA.sol
@@ -333,7 +333,7 @@ library ECDSA {
 
     /// @dev Returns the canonical hash of `signature`.
     function canonicalHash(bytes memory signature) internal pure returns (bytes32 result) {
-        // @solidity memory-safe-assembly
+        /// @solidity memory-safe-assembly
         assembly {
             let l := mload(signature)
             for {} 1 {} {
@@ -369,7 +369,7 @@ library ECDSA {
         pure
         returns (bytes32 result)
     {
-        // @solidity memory-safe-assembly
+        /// @solidity memory-safe-assembly
         assembly {
             for {} 1 {} {
                 mstore(0x00, calldataload(signature.offset)) // `r`.
@@ -400,7 +400,7 @@ library ECDSA {
 
     /// @dev Returns the canonical hash of `signature`.
     function canonicalHash(bytes32 r, bytes32 vs) internal pure returns (bytes32 result) {
-        // @solidity memory-safe-assembly
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, r) // `r`.
             let v := add(shr(255, vs), 27)
@@ -414,7 +414,7 @@ library ECDSA {
 
     /// @dev Returns the canonical hash of `signature`.
     function canonicalHash(uint8 v, bytes32 r, bytes32 s) internal pure returns (bytes32 result) {
-        // @solidity memory-safe-assembly
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, r) // `r`.
             if iszero(lt(s, _HALF_N_PLUS_1)) {

--- a/src/utils/LibBytes.sol
+++ b/src/utils/LibBytes.sol
@@ -645,6 +645,7 @@ library LibBytes {
 
     /// @dev Directly returns `a` without copying.
     function directReturn(bytes memory a) internal pure {
+        /// @solidity memory-safe-assembly
         assembly {
             // Assumes that the bytes does not start from the scratch space.
             let retStart := sub(a, 0x20)
@@ -660,6 +661,7 @@ library LibBytes {
 
     /// @dev Directly returns `a` with minimal copying.
     function directReturn(bytes[] memory a) internal pure {
+        /// @solidity memory-safe-assembly
         assembly {
             let n := mload(a) // `a.length`.
             let o := add(a, 0x20) // Start of elements in `a`.

--- a/src/utils/LibString.sol
+++ b/src/utils/LibString.sol
@@ -956,6 +956,7 @@ library LibString {
 
     /// @dev Directly returns `a` without copying.
     function directReturn(string memory a) internal pure {
+        /// @solidity memory-safe-assembly
         assembly {
             // Assumes that the string does not start from the scratch space.
             let retStart := sub(a, 0x20)

--- a/src/utils/g/DynamicArrayLib.sol
+++ b/src/utils/g/DynamicArrayLib.sol
@@ -351,6 +351,7 @@ library DynamicArrayLib {
 
     /// @dev Directly returns `a` without copying.
     function directReturn(uint256[] memory a) internal pure {
+        /// @solidity memory-safe-assembly
         assembly {
             let retStart := sub(a, 0x20)
             mstore(retStart, 0x20)
@@ -992,6 +993,7 @@ library DynamicArrayLib {
 
     /// @dev Directly returns `a` without copying.
     function directReturn(DynamicArray memory a) internal pure {
+        /// @solidity memory-safe-assembly
         assembly {
             let arrData := mload(a)
             let retStart := sub(arrData, 0x20)

--- a/src/utils/g/LibBytes.sol
+++ b/src/utils/g/LibBytes.sol
@@ -649,6 +649,7 @@ library LibBytes {
 
     /// @dev Directly returns `a` without copying.
     function directReturn(bytes memory a) internal pure {
+        /// @solidity memory-safe-assembly
         assembly {
             // Assumes that the bytes does not start from the scratch space.
             let retStart := sub(a, 0x20)
@@ -664,6 +665,7 @@ library LibBytes {
 
     /// @dev Directly returns `a` with minimal copying.
     function directReturn(bytes[] memory a) internal pure {
+        /// @solidity memory-safe-assembly
         assembly {
             let n := mload(a) // `a.length`.
             let o := add(a, 0x20) // Start of elements in `a`.

--- a/src/utils/g/LibString.sol
+++ b/src/utils/g/LibString.sol
@@ -960,6 +960,7 @@ library LibString {
 
     /// @dev Directly returns `a` without copying.
     function directReturn(string memory a) internal pure {
+        /// @solidity memory-safe-assembly
         assembly {
             // Assumes that the string does not start from the scratch space.
             let retStart := sub(a, 0x20)


### PR DESCRIPTION
## Description

https://docs.soliditylang.org/en/latest/assembly.html#advanced-safe-use-of-memory

Beyond the strict definition of memory-safety given above, there are cases in which you may want to use more than 64 bytes of scratch space starting at memory offset 0. If you are careful, it can be admissible to use memory up to (and not including) offset 0x80 and still safely declare the assembly block as memory-safe. This is admissible under either of the following conditions:

- By the end of the assembly block, the free memory pointer at offset 0x40 is restored to a sane value (i.e. it is either restored to its original value or an increment of it due to a manual memory allocation), and the memory word at offset 0x60 is restored to a value of zero.

- The assembly block terminates, i.e. execution can never return to high-level Solidity code. This is the case, for example, if your assembly block unconditionally ends in calling the revert opcode.


## Checklist

Ensure you completed **all of the steps** below before submitting your pull request:

- [x] Ran `forge fmt`?
- [x] Ran `forge test`?

_Pull requests with an incomplete checklist will be thrown out._

<!--     Emoji Table:     -->
<!-- readme/docs       📝 -->
<!-- new feature       ✨ -->
<!-- refactor/cleanup  ♻️ -->
<!-- nit               🥢 -->
<!-- security fix      🔒 -->
<!-- optimization      ⚡️ -->
<!-- configuration     👷‍♂️ -->
<!-- events            🔊 -->
<!-- bug fix           🐞 -->
