### PR TITLE
✨ Improve EIP7702Proxy and add LibEIP7702

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ accounts
 ├─ ERC6551 — "Simple ERC6551 account implementation"
 ├─ ERC6551Proxy — "Relay proxy for upgradeable ERC6551 accounts"
 ├─ ERC7821 — "Minimal batch executor mixin"
+├─ LibEIP7702 — "Library for EIP7702 operations"
 ├─ LibERC6551 — "Library for interacting with ERC6551 accounts"
 ├─ LibERC7579 — "Library for handling ERC7579 mode and execution data"
 ├─ Receiver — "Receiver mixin for ETH and safe-transferred ERC721 and ERC1155 tokens"

--- a/foundry.toml
+++ b/foundry.toml
@@ -10,14 +10,14 @@ auto_detect_solc = false
 optimizer = true
 optimizer_runs = 1_000
 gas_limit = 100_000_000 # ETH is 30M, but we use a higher value.
-skip = ["*/*Transient*", "*/ext/ithaca/*", "*/ext/zksync/*"]
+skip = ["*/*7702*", "*/*Transient*", "*/ext/ithaca/*", "*/ext/zksync/*"]
 fs_permissions = [{ access = "read", path = "./test/data"}]
 remappings = [
   "forge-std=test/utils/forge-std/"
 ]
 
 [profile.pre_global_structs]
-skip = ["*/g/*", "*/*Transient*", "*/ext/ithaca/*", "*/ext/zksync/*"]
+skip = ["*/g/*", "*/*7702*", "*/*Transient*", "*/ext/ithaca/*", "*/ext/zksync/*"]
 
 [profile.post_cancun]
 evm_version = "cancun"

--- a/src/Milady.sol
+++ b/src/Milady.sol
@@ -8,6 +8,7 @@ import "./accounts/ERC4337Factory.sol";
 import "./accounts/ERC6551.sol";
 import "./accounts/ERC6551Proxy.sol";
 import "./accounts/ERC7821.sol";
+import "./accounts/LibEIP7702.sol";
 import "./accounts/LibERC6551.sol";
 import "./accounts/LibERC7579.sol";
 import "./accounts/Receiver.sol";

--- a/src/Milady.sol
+++ b/src/Milady.sol
@@ -1,14 +1,12 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.4;
 
-import "./accounts/EIP7702Proxy.sol";
 import "./accounts/ERC1271.sol";
 import "./accounts/ERC4337.sol";
 import "./accounts/ERC4337Factory.sol";
 import "./accounts/ERC6551.sol";
 import "./accounts/ERC6551Proxy.sol";
 import "./accounts/ERC7821.sol";
-import "./accounts/LibEIP7702.sol";
 import "./accounts/LibERC6551.sol";
 import "./accounts/LibERC7579.sol";
 import "./accounts/Receiver.sol";

--- a/src/accounts/EIP7702Proxy.sol
+++ b/src/accounts/EIP7702Proxy.sol
@@ -119,12 +119,11 @@ contract EIP7702Proxy {
                     revert(0x00, returndatasize())
                 }
                 // Because we cannot reliably and efficiently tell if the call is made
-                // via staticcall or call, we shall ask the delegation to request a
-                // proxy delegation initialization request via the `_ERC1967_IMPLEMENTATION_SLOT`
-                // to signal that we should replace it with the actual implementation.
-                // This also gives the flexibility on whether to let the proxy auto-upgrade,
-                // or let the authority manually upgrade.
-                // A non-zero value in transient storage denotes a initialization request.
+                // via staticcall or call, we shall ask the delegation to make a proxy delegation
+                // initialization request to signal that we should initialize the storage slot with
+                // the actual implementation. This also gives flexibility on whether to let the
+                // proxy auto-upgrade, or let the authority manually upgrade.
+                // A non-zero value in the transient storage denotes a initialization request.
                 if tload(_EIP7702_PROXY_DELEGATION_INITIALIZATION_REQUEST_SLOT) {
                     let implSlot := _ERC1967_IMPLEMENTATION_SLOT
                     // The `implementation` is still at `calldatasize()` in memory.

--- a/src/accounts/EIP7702Proxy.sol
+++ b/src/accounts/EIP7702Proxy.sol
@@ -127,7 +127,7 @@ contract EIP7702Proxy {
                 let implSlot := _ERC1967_IMPLEMENTATION_SLOT
                 if eq(_EIP7702_PROXY_DELEGATION_INITIALIZATION_PREFIX, shr(224, sload(implSlot))) {
                     // The `implementation` is still at `calldatasize()` in memory.
-                    sstore(implSlot, mload(calldatasize()))
+                    sstore(implSlot, or(shl(160, shr(160, impl)), mload(calldatasize())))
                 }
                 returndatacopy(0x00, 0x00, returndatasize())
                 return(0x00, returndatasize())

--- a/src/accounts/EIP7702Proxy.sol
+++ b/src/accounts/EIP7702Proxy.sol
@@ -63,8 +63,8 @@ contract EIP7702Proxy {
                     return(calldatasize(), 0x20)
                 }
                 let fnSel := shr(224, calldataload(0x00))
-                // `implementation()`.
-                if eq(0x5c60da1b, fnSel) {
+                // `implementation()` or `eip7702ProxyImplementation()`.
+                if or(eq(0x5c60da1b, fnSel), eq(0x7dae87cb, fnSel)) {
                     if staticcall(gas(), address(), calldatasize(), 0x00, 0x00, 0x20) {
                         return(0x00, returndatasize())
                     }

--- a/src/accounts/EIP7702Proxy.sol
+++ b/src/accounts/EIP7702Proxy.sol
@@ -122,7 +122,7 @@ contract EIP7702Proxy {
                 // via staticcall or call, we shall ask the delegation to make a proxy delegation
                 // initialization request to signal that we should initialize the storage slot with
                 // the actual implementation. This also gives flexibility on whether to let the
-                // proxy auto-upgrade, or let the authority manually upgrade.
+                // proxy auto-upgrade, or let the authority manually upgrade (via 7702 or passkey).
                 // A non-zero value in the transient storage denotes a initialization request.
                 if tload(_EIP7702_PROXY_DELEGATION_INITIALIZATION_REQUEST_SLOT) {
                     let implSlot := _ERC1967_IMPLEMENTATION_SLOT

--- a/src/accounts/EIP7702Proxy.sol
+++ b/src/accounts/EIP7702Proxy.sol
@@ -33,6 +33,11 @@ contract EIP7702Proxy {
     bytes32 internal constant _ERC1967_ADMIN_SLOT =
         0xb53127684a568b3173ae13b9f8a6016e243e63b6e8ee1178d6a717850b5d6103;
 
+    /// @dev The prefix for the ERC-1967 storage slot value if it should
+    /// be initialized with the latest implementation.
+    /// `uint32(bytes4(keccak256("eip7702.proxy.delegation.initialization")))`
+    uint32 internal constant _EIP7702_PROXY_DELEGATION_INITIALIZATION_PREFIX = 0x17723f10;
+
     /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
     /*                        CONSTRUCTOR                         */
     /*.•°:°.´+˚.*°.˚:*.´•*.+°.•°:´*.´•*.•°.•°:°.´:•˚°.*°.˚:*.´+°.•*/
@@ -99,8 +104,8 @@ contract EIP7702Proxy {
             // Workflow for the EIP7702 authority (i.e. the EOA).
             let impl := sload(_ERC1967_IMPLEMENTATION_SLOT) // The preferred implementation on the EOA.
             calldatacopy(0x00, 0x00, calldatasize()) // Copy the calldata for the delegatecall.
-            // If the EOA's implementation slot is 0, perform the initialization workflow.
-            if iszero(impl) {
+            // If the EOA's implementation, perform the initialization workflow.
+            if iszero(shl(96, impl)) {
                 if iszero(
                     and( // The arguments of `and` are evaluated from right to left.
                         delegatecall(
@@ -114,14 +119,15 @@ contract EIP7702Proxy {
                     revert(0x00, returndatasize())
                 }
                 // Because we cannot reliably and efficiently tell if the call is made
-                // via staticcall or call, we shall ask the delegation to
-                // write `_ERC1967_IMPLEMENTATION_SLOT` to the `_ERC1967_IMPLEMENTATION_SLOT`
+                // via staticcall or call, we shall ask the delegation to request a 
+                // proxy delegation initialization request via the `_ERC1967_IMPLEMENTATION_SLOT`
                 // to signal that we should replace it with the actual implementation.
                 // This also gives the flexibility on whether to let the proxy auto-upgrade,
                 // or let the authority manually upgrade.
-                if eq(sload(_ERC1967_IMPLEMENTATION_SLOT), _ERC1967_IMPLEMENTATION_SLOT) {
+                let implSlot := _ERC1967_IMPLEMENTATION_SLOT
+                if eq(_EIP7702_PROXY_DELEGATION_INITIALIZATION_PREFIX, shr(224, sload(implSlot))) {
                     // The `implementation` is still at `calldatasize()` in memory.
-                    sstore(_ERC1967_IMPLEMENTATION_SLOT, mload(calldatasize()))
+                    sstore(implSlot, mload(calldatasize()))
                 }
                 returndatacopy(0x00, 0x00, returndatasize())
                 return(0x00, returndatasize())

--- a/src/accounts/EIP7702Proxy.sol
+++ b/src/accounts/EIP7702Proxy.sol
@@ -119,7 +119,7 @@ contract EIP7702Proxy {
                     revert(0x00, returndatasize())
                 }
                 // Because we cannot reliably and efficiently tell if the call is made
-                // via staticcall or call, we shall ask the delegation to request a 
+                // via staticcall or call, we shall ask the delegation to request a
                 // proxy delegation initialization request via the `_ERC1967_IMPLEMENTATION_SLOT`
                 // to signal that we should replace it with the actual implementation.
                 // This also gives the flexibility on whether to let the proxy auto-upgrade,

--- a/src/accounts/EIP7702Proxy.sol
+++ b/src/accounts/EIP7702Proxy.sol
@@ -77,7 +77,7 @@ contract EIP7702Proxy {
                 }
                 // Admin workflow.
                 if eq(caller(), admin) {
-                    let addr := shr(96, shl(96, calldataload(0x04)))
+                    let addr := shr(96, calldataload(0x10))
                     // `changeAdmin(address)`.
                     if eq(0x8f283970, fnSel) {
                         sstore(_ERC1967_ADMIN_SLOT, addr)
@@ -119,7 +119,7 @@ contract EIP7702Proxy {
                 // to signal that we should replace it with the actual implementation.
                 // This also gives the flexibility on whether to let the proxy auto-upgrade,
                 // or let the authority manually upgrade.
-                if iszero(xor(sload(_ERC1967_IMPLEMENTATION_SLOT), _ERC1967_IMPLEMENTATION_SLOT)) {
+                if eq(sload(_ERC1967_IMPLEMENTATION_SLOT), _ERC1967_IMPLEMENTATION_SLOT) {
                     // The `implementation` is still at `calldatasize()` in memory.
                     sstore(_ERC1967_IMPLEMENTATION_SLOT, mload(calldatasize()))
                 }

--- a/src/accounts/LibEIP7702.sol
+++ b/src/accounts/LibEIP7702.sol
@@ -139,6 +139,7 @@ library LibEIP7702 {
         /// @solidity memory-safe-assembly
         assembly {
             if iszero(shl(96, sload(ERC1967_IMPLEMENTATION_SLOT))) {
+                // Use a dedicated transient storage slot for better Swiss-cheese-model safety.
                 tstore(_EIP7702_PROXY_DELEGATION_INITIALIZATION_REQUEST_SLOT, address())
             }
         }

--- a/src/accounts/LibEIP7702.sol
+++ b/src/accounts/LibEIP7702.sol
@@ -125,7 +125,10 @@ library LibEIP7702 {
     function upgradeProxyDelegation(address newImplementation) internal {
         /// @solidity memory-safe-assembly
         assembly {
-            sstore(ERC1967_IMPLEMENTATION_SLOT, shr(96, shl(96, newImplementation)))
+            let s := ERC1967_IMPLEMENTATION_SLOT 
+            mstore(0x00, sload(s))
+            mstore(0x0c, shl(96, newImplementation))
+            sstore(s, mload(0x00))
         }
     }
 
@@ -138,8 +141,9 @@ library LibEIP7702 {
             let s := ERC1967_IMPLEMENTATION_SLOT
             let v := sload(s)
             if iszero(shl(96, v)) {
-                let p := EIP7702_PROXY_DELEGATION_INITIALIZATION_PREFIX
-                sstore(s, or(shl(224, p), shr(32, shl(32, v))))
+                mstore(0x20, v)
+                mstore(0x04, EIP7702_PROXY_DELEGATION_INITIALIZATION_PREFIX)
+                sstore(s, mload(0x20))
             }
         }
     }

--- a/src/accounts/LibEIP7702.sol
+++ b/src/accounts/LibEIP7702.sol
@@ -115,7 +115,8 @@ library LibEIP7702 {
     /// To "auto-upgrade" to the latest implementation on the proxy, pass in `address(0)` to reset
     /// the implementation slot. This causes the proxy to use the latest default implementation,
     /// which may be optionally reinitialized via `requestProxyDelegationInitialization()`.
-    /// To be used by delegation implementations pointed to by an EIP7702Proxy.
+    /// This function is intended to be used on the authority of an EIP7702Proxy delegation.
+    /// The most intended usage pattern is to wrap this in an access-gated admin function.
     function upgradeProxyDelegation(address newImplementation) internal {
         /// @solidity memory-safe-assembly
         assembly {
@@ -124,7 +125,8 @@ library LibEIP7702 {
     }
 
     /// @dev Requests the implementation to be initialized to the latest implementation on the proxy.
-    /// To be used by delegation implementations pointed to by an EIP7702Proxy.
+    /// This function is intended to be used on the authority of an EIP7702Proxy delegation.
+    /// The most intended usage pattern is to place it at the end of an `execute` function.
     function requestProxyDelegationInitialization() internal {
         /// @solidity memory-safe-assembly
         assembly {

--- a/src/accounts/LibEIP7702.sol
+++ b/src/accounts/LibEIP7702.sol
@@ -1,0 +1,127 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.4;
+
+/// @notice Library for EIP7702 operations.
+/// @author Solady (https://github.com/vectorized/solady/blob/main/src/accounts/LibEIP7702.sol)
+library LibEIP7702 {
+    /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
+    /*                       CUSTOM ERRORS                        */
+    /*.•°:°.´+˚.*°.˚:*.´•*.+°.•°:´*.´•*.•°.•°:°.´:•˚°.*°.˚:*.´+°.•*/
+
+    /// @dev Failed to perform the proxy query.
+    error ProxyQueryFailed();
+
+    /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
+    /*                         CONSTANTS                          */
+    /*.•°:°.´+˚.*°.˚:*.´•*.+°.•°:´*.´•*.•°.•°:°.´:•˚°.*°.˚:*.´+°.•*/
+
+    /// @dev The ERC-1967 storage slot for the implementation in the proxy.
+    /// `uint256(keccak256("eip1967.proxy.implementation")) - 1`.
+    bytes32 internal constant ERC1967_IMPLEMENTATION_SLOT =
+        0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc;
+
+    /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
+    /*                    AUTHORITY OPERATIONS                    */
+    /*.•°:°.´+˚.*°.˚:*.´•*.+°.•°:´*.´•*.•°.•°:°.´:•˚°.*°.˚:*.´+°.•*/
+
+    /// @dev Returns the delegation of the account.
+    /// If the account is not an EIP7702 authority, the `delegation` will be `address(0)`.
+    function delegation(address account) internal view returns (address result) {
+        /// @solidity memory-safe-assembly
+        assembly {
+            extcodecopy(account, 0x00, 0x00, 0x20)
+            result :=
+                mul(
+                    shr(96, mload(0x03)),
+                    and(eq(0xef0100, shr(232, mload(0x00))), eq(extcodesize(account), 23))
+                )
+        }
+    }
+
+    /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
+    /*                      PROXY OPERATIONS                      */
+    /*.•°:°.´+˚.*°.˚:*.´•*.+°.•°:´*.´•*.•°.•°:°.´:•˚°.*°.˚:*.´+°.•*/
+
+    /// @dev Returns the implementation of the proxy.
+    function proxyImplementation(address proxy) internal view returns (address result) {
+        /// @solidity memory-safe-assembly
+        assembly {
+            if iszero(mul(returndatasize(), staticcall(gas(), proxy, 0x00, 0x00, 0x00, 0x20))) {
+                mstore(0x00, 0x26ec9b6a) // `ProxyQueryFailed()`.
+                revert(0x1c, 0x04)
+            }
+            result := mload(0x00)
+        }
+    }
+
+    /// @dev Returns the admin of the proxy.
+    function proxyAdmin(address proxy) internal view returns (address result) {
+        /// @solidity memory-safe-assembly
+        assembly {
+            mstore(0x00, 0xf851a440) // `admin()`.
+            if iszero(mul(returndatasize(), staticcall(gas(), proxy, 0x1c, 0x04, 0x00, 0x20))) {
+                mstore(0x00, 0x26ec9b6a) // `ProxyQueryFailed()`.
+                revert(0x1c, 0x04)
+            }
+            result := mload(0x00)
+        }
+    }
+
+    /// @dev Changes the admin on the proxy. The caller must be the admin.
+    function changeProxyAdmin(address proxy, address newAdmin) internal {
+        /// @solidity memory-safe-assembly
+        assembly {
+            mstore(0x00, 0x8f283970) // `changeAdmin(address)`.
+            mstore(0x20, shr(96, shl(96, newAdmin)))
+            if iszero(and(eq(mload(0x00), 1), call(gas(), proxy, 0, 0x1c, 0x24, 0x00, 0x20))) {
+                mstore(0x00, 0x26ec9b6a) // `ProxyQueryFailed()`.
+                revert(0x1c, 0x04)
+            }
+        }
+    }
+
+    /// @dev Changes the implementation on the proxy. The caller must be the admin.
+    function upgradeProxy(address proxy, address newImplementation) internal {
+        /// @solidity memory-safe-assembly
+        assembly {
+            mstore(0x00, 0x0900f010) // `upgrade(address)`.
+            mstore(0x20, shr(96, shl(96, newImplementation)))
+            if iszero(and(eq(mload(0x00), 1), call(gas(), proxy, 0, 0x1c, 0x24, 0x00, 0x20))) {
+                mstore(0x00, 0x26ec9b6a) // `ProxyQueryFailed()`.
+                revert(0x1c, 0x04)
+            }
+        }
+    }
+
+    /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
+    /*                PROXY DELEGATION OPERATIONS                 */
+    /*.•°:°.´+˚.*°.˚:*.´•*.+°.•°:´*.´•*.•°.•°:°.´:•˚°.*°.˚:*.´+°.•*/
+
+    /// @dev Upgrades the implementation to the latest implementation on the proxy.
+    /// To be used by delegation implementations pointed to by an EIP7702Proxy.
+    function upgradeToLatestProxyDelegation() internal {
+        address proxy = delegation(address(this));
+        if (proxy != address(0)) {
+            upgradeProxyDelegation(proxyImplementation(proxy));
+        }
+    }
+
+    /// @dev Upgrades the implementation.
+    /// To be used by delegation implementations pointed to by an EIP7702Proxy.
+    function upgradeProxyDelegation(address newImplementation) internal {
+        /// @solidity memory-safe-assembly
+        assembly {
+            sstore(ERC1967_IMPLEMENTATION_SLOT, shr(96, shl(96, newImplementation)))
+        }
+    }
+
+    /// @dev Requests the implementation to be initialized to the latest implementation on the proxy.
+    /// To be used by delegation implementations pointed to by an EIP7702Proxy.
+    function requestProxyDelegationInitialization() internal {
+        /// @solidity memory-safe-assembly
+        assembly {
+            let implSlot := ERC1967_IMPLEMENTATION_SLOT
+            if iszero(sload(implSlot)) { sstore(implSlot, implSlot) }
+        }
+    }
+}

--- a/src/accounts/LibEIP7702.sol
+++ b/src/accounts/LibEIP7702.sol
@@ -30,11 +30,9 @@ library LibEIP7702 {
         /// @solidity memory-safe-assembly
         assembly {
             extcodecopy(account, 0x00, 0x00, 0x20)
-            result :=
-                mul(
-                    shr(96, mload(0x03)),
-                    and(eq(0xef0100, shr(232, mload(0x00))), eq(extcodesize(account), 23))
-                )
+            // Note: checking that it starts with hex"ef01" is the most general and futureproof.
+            // 7702 bytecode is `abi.encodePacked(hex"ef01", uint8(version), address(delegation))`.
+            result := mul(shr(96, mload(0x03)), eq(0xef01, shr(240, mload(0x00))))
         }
     }
 

--- a/src/accounts/LibEIP7702.sol
+++ b/src/accounts/LibEIP7702.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.4;
+pragma solidity ^0.8.24;
 
 /// @notice Library for EIP7702 operations.
 /// @author Solady (https://github.com/vectorized/solady/blob/main/src/accounts/LibEIP7702.sol)
@@ -26,10 +26,10 @@ library LibEIP7702 {
     bytes32 internal constant ERC1967_IMPLEMENTATION_SLOT =
         0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc;
 
-    /// @dev The prefix for the ERC-1967 storage slot value if it should
-    /// be initialized with the latest implementation.
-    /// `uint32(bytes4(keccak256("eip7702.proxy.delegation.initialization")))`
-    uint32 internal constant EIP7702_PROXY_DELEGATION_INITIALIZATION_PREFIX = 0x17723f10;
+    /// @dev The transient storage slot for requesting the proxy to initialize the implementation.
+    /// `uint256(keccak256("eip7702.proxy.delegation.initialization.request")) - 1`.
+    bytes32 internal constant _EIP7702_PROXY_DELEGATION_INITIALIZATION_REQUEST_SLOT =
+        0x94e11c6e41e7fb92cb8bb65e13fdfbd4eba8b831292a1a220f7915c78c7c078f;
 
     /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
     /*                    AUTHORITY OPERATIONS                    */
@@ -138,12 +138,8 @@ library LibEIP7702 {
     function requestProxyDelegationInitialization() internal {
         /// @solidity memory-safe-assembly
         assembly {
-            let s := ERC1967_IMPLEMENTATION_SLOT
-            let v := sload(s)
-            if iszero(shl(96, v)) {
-                mstore(0x20, v)
-                mstore(0x04, EIP7702_PROXY_DELEGATION_INITIALIZATION_PREFIX)
-                sstore(s, mload(0x20))
+            if iszero(shl(96, sload(ERC1967_IMPLEMENTATION_SLOT))) {
+                tstore(_EIP7702_PROXY_DELEGATION_INITIALIZATION_REQUEST_SLOT, address())
             }
         }
     }

--- a/src/accounts/LibEIP7702.sol
+++ b/src/accounts/LibEIP7702.sol
@@ -26,6 +26,11 @@ library LibEIP7702 {
     bytes32 internal constant ERC1967_IMPLEMENTATION_SLOT =
         0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc;
 
+    /// @dev The prefix for the ERC-1967 storage slot value if it should
+    /// be initialized with the latest implementation.
+    /// `uint32(bytes4(keccak256("eip7702.proxy.delegation.initialization")))`
+    uint32 internal constant EIP7702_PROXY_DELEGATION_INITIALIZATION_PREFIX = 0x17723f10;
+
     /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
     /*                    AUTHORITY OPERATIONS                    */
     /*.•°:°.´+˚.*°.˚:*.´•*.+°.•°:´*.´•*.•°.•°:°.´:•˚°.*°.˚:*.´+°.•*/
@@ -130,8 +135,12 @@ library LibEIP7702 {
     function requestProxyDelegationInitialization() internal {
         /// @solidity memory-safe-assembly
         assembly {
-            let implSlot := ERC1967_IMPLEMENTATION_SLOT
-            if iszero(sload(implSlot)) { sstore(implSlot, implSlot) }
+            let s := ERC1967_IMPLEMENTATION_SLOT
+            let v := sload(s)
+            if iszero(v) {
+                let p := EIP7702_PROXY_DELEGATION_INITIALIZATION_PREFIX
+                sstore(s, or(shl(224, p), shr(32, shl(32, v))))
+            }
         }
     }
 }

--- a/src/accounts/LibEIP7702.sol
+++ b/src/accounts/LibEIP7702.sol
@@ -137,7 +137,7 @@ library LibEIP7702 {
         assembly {
             let s := ERC1967_IMPLEMENTATION_SLOT
             let v := sload(s)
-            if iszero(v) {
+            if iszero(shl(96, v)) {
                 let p := EIP7702_PROXY_DELEGATION_INITIALIZATION_PREFIX
                 sstore(s, or(shl(224, p), shr(32, shl(32, v))))
             }

--- a/src/accounts/LibEIP7702.sol
+++ b/src/accounts/LibEIP7702.sol
@@ -125,7 +125,7 @@ library LibEIP7702 {
     function upgradeProxyDelegation(address newImplementation) internal {
         /// @solidity memory-safe-assembly
         assembly {
-            let s := ERC1967_IMPLEMENTATION_SLOT 
+            let s := ERC1967_IMPLEMENTATION_SLOT
             mstore(0x00, sload(s))
             mstore(0x0c, shl(96, newImplementation))
             sstore(s, mload(0x00))

--- a/src/accounts/LibEIP7702.sol
+++ b/src/accounts/LibEIP7702.sol
@@ -110,16 +110,11 @@ library LibEIP7702 {
     /*                PROXY DELEGATION OPERATIONS                 */
     /*.•°:°.´+˚.*°.˚:*.´•*.+°.•°:´*.´•*.•°.•°:°.´:•˚°.*°.˚:*.´+°.•*/
 
-    /// @dev Upgrades the implementation to the latest implementation on the proxy.
-    /// To be used by delegation implementations pointed to by an EIP7702Proxy.
-    function upgradeToLatestProxyDelegation() internal {
-        address proxy = delegation(address(this));
-        if (proxy != address(0)) {
-            upgradeProxyDelegation(proxyImplementation(proxy));
-        }
-    }
-
     /// @dev Upgrades the implementation.
+    /// The new implementation will NOT be active until the next UserOp or transaction.
+    /// To "auto-upgrade" to the latest implementation on the proxy, pass in `address(0)` to reset
+    /// the implementation slot. This causes the proxy to use the latest default implementation,
+    /// which may be optionally reinitialized via `requestProxyDelegationInitialization()`.
     /// To be used by delegation implementations pointed to by an EIP7702Proxy.
     function upgradeProxyDelegation(address newImplementation) internal {
         /// @solidity memory-safe-assembly

--- a/src/accounts/LibEIP7702.sol
+++ b/src/accounts/LibEIP7702.sol
@@ -36,7 +36,7 @@ library LibEIP7702 {
         /// @solidity memory-safe-assembly
         assembly {
             extcodecopy(account, 0x00, 0x00, 0x20)
-            // Note: checking that it starts with hex"ef01" is the most general and futureproof.
+            // Note: Checking that it starts with hex"ef01" is the most general and futureproof.
             // 7702 bytecode is `abi.encodePacked(hex"ef01", uint8(version), address(delegation))`.
             result := mul(shr(96, mload(0x03)), eq(0xef01, shr(240, mload(0x00))))
         }

--- a/test/EIP7702Proxy.t.sol
+++ b/test/EIP7702Proxy.t.sol
@@ -44,7 +44,7 @@ contract EIP7702ProxyTest is SoladyTest {
     }
 
     function upgradeToLatestProxyDelegation() public {
-        LibEIP7702.upgradeToLatestProxyDelegation();
+        LibEIP7702.upgradeProxyDelegation(address(0));
     }
 
     function _checkBehavesLikeProxy(address instance) internal {

--- a/test/EIP7702Proxy.t.sol
+++ b/test/EIP7702Proxy.t.sol
@@ -66,7 +66,7 @@ contract EIP7702ProxyTest is SoladyTest {
         }
         EIP7702ProxyTest(instance).setValue(v);
         assertEq(v, EIP7702ProxyTest(instance).value());
-        
+
         assertEq(thisValue, this.value());
         vm.expectRevert(abi.encodeWithSelector(CustomError.selector, v));
         EIP7702ProxyTest(instance).revertWithError();
@@ -123,7 +123,7 @@ contract EIP7702ProxyTest is SoladyTest {
 
         uint256 r = (_random() >> 160) << 160;
         vm.store(address(this), _ERC1967_IMPLEMENTATION_SLOT, bytes32(r));
-        
+
         if (!f && _randomChance(16)) {
             address newImplementation = _randomUniqueHashedAddress();
             LibEIP7702.upgradeProxyDelegation(newImplementation);
@@ -170,7 +170,7 @@ contract EIP7702ProxyTest is SoladyTest {
             vm.stopPrank();
             EIP7702ProxyTest(authority).unsetProxyDelegation();
             assertEq(Implementation2(authority).version(), 2);
-        
+
             uint256 loaded = uint256(vm.load(authority, _ERC1967_IMPLEMENTATION_SLOT));
             assertEq(address(uint160(loaded)), address(0));
             assertEq(loaded >> 160, r >> 160);

--- a/test/EIP7702Proxy.t.sol
+++ b/test/EIP7702Proxy.t.sol
@@ -32,14 +32,15 @@ contract EIP7702ProxyTest is SoladyTest {
 
     function setValue(uint256 value_) public {
         value = value_;
+        LibEIP7702.requestProxyDelegationInitialization();
     }
 
     function revertWithError() public view {
         revert CustomError(value);
     }
 
-    function requestProxyDelegationInitialization() public {
-        LibEIP7702.requestProxyDelegationInitialization();
+    function version() external pure returns (uint256) {
+        return 1;
     }
 
     function upgradeToLatestProxyDelegation() public {
@@ -48,6 +49,8 @@ contract EIP7702ProxyTest is SoladyTest {
 
     function _checkBehavesLikeProxy(address instance) internal {
         assertTrue(instance != address(0));
+
+        assertEq(EIP7702ProxyTest(instance).version(), 1);
 
         uint256 v = _random();
         uint256 thisValue = this.value();
@@ -129,8 +132,6 @@ contract EIP7702ProxyTest is SoladyTest {
         assertEq(LibEIP7702.delegation(authority), address(eip7702Proxy));
 
         _checkBehavesLikeProxy(authority);
-
-        EIP7702ProxyTest(authority).requestProxyDelegationInitialization();
 
         // Check that upgrading the proxy won't cause the authority's implementation to change.
         if (!f && _randomChance(2)) {


### PR DESCRIPTION
## Description

LibEIP7702 makes it neater to work with the proxy.

Principles:

- Try to preserve the upper 96 bits. Just in case some weird delegation saved some values in there.
- Use transient storage to pass the request. Technically, we can just use regular storage, without much overhead, cuz it's warm. But I am worried about the super edge case where someone actually use the upper 96 bits. Also it's cheaper for the case of direct delegation (no via EIP7702Proxy).

## Checklist

Ensure you completed **all of the steps** below before submitting your pull request:

- [x] Ran `forge fmt`?
- [x] Ran `forge test`?

_Pull requests with an incomplete checklist will be thrown out._

<!--     Emoji Table:     -->
<!-- readme/docs       📝 -->
<!-- new feature       ✨ -->
<!-- refactor/cleanup  ♻️ -->
<!-- nit               🥢 -->
<!-- security fix      🔒 -->
<!-- optimization      ⚡️ -->
<!-- configuration     👷‍♂️ -->
<!-- events            🔊 -->
<!-- bug fix           🐞 -->
