### PR TITLE
🥢 Update Permit2 comment

### DIFF
--- a/src/tokens/ERC20.sol
+++ b/src/tokens/ERC20.sol
@@ -119,7 +119,7 @@ abstract contract ERC20 {
 
     /// @dev The canonical Permit2 address.
     /// For signature-based allowance granting for single transaction ERC20 `transferFrom`.
-    /// To enable, override `_givePermit2InfiniteAllowance()`.
+    /// Enabled by default. To disable, override `_givePermit2InfiniteAllowance()`.
     /// [Github](https://github.com/Uniswap/permit2)
     /// [Etherscan](https://etherscan.io/address/0x000000000022D473030F116dDEE9F6B43aC78BA3)
     address internal constant _PERMIT2 = 0x000000000022D473030F116dDEE9F6B43aC78BA3;


### PR DESCRIPTION
## Description

Updated documentation to clarify that Permit2 is enabled by default and only requires overriding to disable.
https://github.com/Vectorized/solady/blob/09cdd7c8d4b4d83ab7b0c1e313df05310c4fc920/src/tokens/ERC20.sol#L668

