### PR TITLE
⚡️ Use ERC-4337 `receive` again

### DIFF
--- a/src/accounts/ERC4337.sol
+++ b/src/accounts/ERC4337.sol
@@ -356,11 +356,9 @@ abstract contract ERC4337 is Ownable, UUPSUpgradeable, Receiver, ERC1271 {
         address ep = entryPoint();
         /// @solidity memory-safe-assembly
         assembly {
-            // Call `depositTo(address)` instead of `receive()` for better standard compliance.
-            mstore(0x00, 0xb760faf9) // `depositTo(address)`.
-            mstore(0x20, address()) // `account`.
+            // The EntryPoint has balance accounting logic in the `receive()` function, as defined in ERC-4337.
             // forgefmt: disable-next-item
-            if iszero(mul(extcodesize(ep), call(gas(), ep, callvalue(), 0x1c, 0x24, codesize(), 0x00))) {
+            if iszero(mul(extcodesize(ep), call(gas(), ep, callvalue(), codesize(), 0x00, codesize(), 0x00))) {
                 revert(codesize(), 0x00) // For gas estimation.
             }
         }


### PR DESCRIPTION
## Description

Undo changes done in [465e41c](https://github.com/Vectorized/solady/commit/465e41c87238ca86972e38b07fb1176513a441ad) since ERC-4337 has been updated to define the presence of a `receive` function in the `EntryPoint`.

Closes: https://github.com/Vectorized/solady/issues/1365

## Checklist

Ensure you completed **all of the steps** below before submitting your pull request:

- [x] Ran `forge fmt`?
- [x] Ran `forge test`?

_Pull requests with an incomplete checklist will be thrown out._

<!--     Emoji Table:     -->
<!-- readme/docs       📝 -->
<!-- new feature       ✨ -->
<!-- refactor/cleanup  ♻️ -->
<!-- nit               🥢 -->
<!-- security fix      🔒 -->
<!-- optimization      ⚡️ -->
<!-- configuration     👷‍♂️ -->
<!-- events            🔊 -->
<!-- bug fix           🐞 -->
