### PR TITLE
🥢 Fix typos in test function names

### DIFF
--- a/test/LibPRNG.t.sol
+++ b/test/LibPRNG.t.sol
@@ -589,7 +589,7 @@ contract LibPRNGTest is SoladyTest {
         this.lazyShufflerNext(_random());
     }
 
-    function testLazyShufflerRevertsOnFinshedNext(uint256 n) public {
+    function testLazyShufflerRevertsOnFinishedNext(uint256 n) public {
         n = _bound(n, 1, 3);
         _lazyShuffler0.initialize(n);
         unchecked {

--- a/test/LibSort.t.sol
+++ b/test/LibSort.t.sol
@@ -37,7 +37,7 @@ contract LibSortTest is SoladyTest {
         testInsertionSortPsuedorandom(123456789);
     }
 
-    function testSortChecksumed(uint256) public {
+    function testSortChecksummed(uint256) public {
         unchecked {
             uint256 n = _randomArrayLength();
             uint256[] memory a = _randomUints(n);


### PR DESCRIPTION
## **Description:**



This PR corrects spelling mistakes in two test function names:
- `testLazyShufflerRevertsOnFinshedNext` -> `testLazyShufflerRevertsOnFinishedNext`
- `testSortChecksumed` -> `testSortChecksummed`

The changes are purely cosmetic and fix misspellings in function names without modifying any functionality.

Files modified:
- test/LibPRNG.t.sol
- test/LibSort.t.sol
