### PR TITLE
🥢 Rename check_EcrecoverTrickEquivalance function to fix typo

### DIFF
--- a/test/SignatureCheckerLib.t.sol
+++ b/test/SignatureCheckerLib.t.sol
@@ -634,7 +634,7 @@ contract SignatureCheckerLibTest is SoladyTest {
         assertEq(t.smartAccount.code.length, 0);
     }
 
-    function check_EcrecoverTrickEquivalance(bool success, uint256 signer, uint256 recovered)
+    function check_EcrecoverTrickEquivalence(bool success, uint256 signer, uint256 recovered)
         public
         pure
     {
@@ -648,11 +648,11 @@ contract SignatureCheckerLibTest is SoladyTest {
         assert(optimized == expected);
     }
 
-    function testEcrecoverTrickEquivalance(bool success, uint256 signer, uint256 recovered)
+    function testEcrecoverTrickEquivalence(bool success, uint256 signer, uint256 recovered)
         public
         pure
     {
-        check_EcrecoverTrickEquivalance(success, signer, recovered);
+        check_EcrecoverTrickEquivalence(success, signer, recovered);
     }
 
     function check_EcrecoverLoopTrick(uint256 n) public pure {


### PR DESCRIPTION
## Description

This PR fixes a typo in the function name by renaming:
- check_EcrecoverTrickEquivalance -> check_EcrecoverTrickEquivalence
- testEcrecoverTrickEquivalance -> testEcrecoverTrickEquivalence

The change corrects the spelling of "Equivalance" to "Equivalence" in the function names while maintaining the same functionality.