### PR TITLE
✨ LibBytes indexOfByte

### DIFF
--- a/src/utils/LibBytes.sol
+++ b/src/utils/LibBytes.sol
@@ -329,8 +329,12 @@ library LibBytes {
                         // forgefmt: disable-next-item
                         lzc := add(xor(lzc, byte(and(0x1f, shr(shr(lzc, flags), 0x8421084210842108cc6318c6db6d54be)),
                             0xf8f9f9faf9fdfafbf9fdfcfdfafbfcfef9fafdfafcfcfbfefafafcfbffffffff)), 0) // iszero(zeroes) is 0
-                        // Then we add chunk offset to byte offset
-                        result := add(sub(subject, subjectStart), shr(3, lzc))
+
+                        // Then we add chunk offset to byte offset and ensure it's within bounds
+                        let offset := add(sub(subject, subjectStart), shr(3, lzc))
+                        if iszero(lt(offset, subjectLen)) { break }
+
+                        result := offset
                         break
                     }
                 }

--- a/src/utils/LibBytes.sol
+++ b/src/utils/LibBytes.sol
@@ -297,10 +297,10 @@ library LibBytes {
                 if iszero(gt(subjectLen, from)) { break }
 
                 // Build mask by replicating `needle` across all 32 bytes
-                // We shift needle to ensure it's a byte
+                // We isolate the first byte of needle to ensure it's valid
                 // forgefmt: disable-next-item
                 let needleMask :=
-                    mul(shr(248, needle), 0x0101010101010101010101010101010101010101010101010101010101010101)
+                    mul(byte(0, needle), 0x0101010101010101010101010101010101010101010101010101010101010101)
 
                 // Check for existing matches chunk by chunk
                 for {} lt(subject, end) { subject := add(subject, 0x20) } {

--- a/src/utils/LibString.sol
+++ b/src/utils/LibString.sol
@@ -555,6 +555,24 @@ library LibString {
     }
 
     /// @dev Returns the byte index of the first location of `needle` in `subject`,
+    /// needleing from left to right, starting from `from`. Optimized for byte needles.
+    /// Returns `NOT_FOUND` (i.e. `type(uint256).max`) if the `needle` is not found.
+    function indexOf(string memory subject, uint8 needle, uint256 from)
+        internal
+        pure
+        returns (uint256 result)
+    {
+        return LibBytes.indexOf(bytes(subject), needle, from);
+    }
+
+    /// @dev Returns the byte index of the first location of `needle` in `subject`,
+    /// needleing from left to right. Optimized for byte needles.
+    /// Returns `NOT_FOUND` (i.e. `type(uint256).max`) if the `needle` is not found.
+    function indexOf(string memory subject, uint8 needle) internal pure returns (uint256 result) {
+        return LibBytes.indexOf(bytes(subject), needle, 0);
+    }
+
+    /// @dev Returns the byte index of the first location of `needle` in `subject`,
     /// needleing from right to left, starting from `from`.
     /// Returns `NOT_FOUND` (i.e. `type(uint256).max`) if the `needle` is not found.
     function lastIndexOf(string memory subject, string memory needle, uint256 from)

--- a/src/utils/LibString.sol
+++ b/src/utils/LibString.sol
@@ -557,19 +557,23 @@ library LibString {
     /// @dev Returns the byte index of the first location of `needle` in `subject`,
     /// needleing from left to right, starting from `from`. Optimized for byte needles.
     /// Returns `NOT_FOUND` (i.e. `type(uint256).max`) if the `needle` is not found.
-    function indexOf(string memory subject, uint8 needle, uint256 from)
+    function indexOfByte(string memory subject, bytes1 needle, uint256 from)
         internal
         pure
         returns (uint256 result)
     {
-        return LibBytes.indexOf(bytes(subject), needle, from);
+        return LibBytes.indexOfByte(bytes(subject), needle, from);
     }
 
     /// @dev Returns the byte index of the first location of `needle` in `subject`,
     /// needleing from left to right. Optimized for byte needles.
     /// Returns `NOT_FOUND` (i.e. `type(uint256).max`) if the `needle` is not found.
-    function indexOf(string memory subject, uint8 needle) internal pure returns (uint256 result) {
-        return LibBytes.indexOf(bytes(subject), needle, 0);
+    function indexOfByte(string memory subject, bytes1 needle)
+        internal
+        pure
+        returns (uint256 result)
+    {
+        return LibBytes.indexOfByte(bytes(subject), needle, 0);
     }
 
     /// @dev Returns the byte index of the first location of `needle` in `subject`,

--- a/test/LibString.t.sol
+++ b/test/LibString.t.sol
@@ -637,21 +637,18 @@ contract LibStringTest is SoladyTest {
         assertEq(LibString.indexOf("accd", "bcd"), LibString.NOT_FOUND);
         assertEq(LibString.indexOf("", "bcd"), LibString.NOT_FOUND);
 
-        assertEq(LibString.indexOf("", uint8(bytes1("a"))), LibString.NOT_FOUND);
-        assertEq(LibString.indexOf("", uint8(bytes1("a")), 1), LibString.NOT_FOUND);
-        assertEq(LibString.indexOf(subject, uint8(bytes1("a")), 0), 0);
-        assertEq(LibString.indexOf(subject, uint8(bytes1("a")), 1), LibString.NOT_FOUND);
-        assertEq(LibString.indexOf(subject, uint8(bytes1("b"))), 1);
-        assertEq(LibString.indexOf(subject, uint8(bytes1("X"))), 49);
-        assertEq(LibString.indexOf(subject, uint8(bytes1("q"))), 16);
-        assertEq(LibString.indexOf(subject, uint8(bytes1("q")), 16), 16);
-        assertEq(LibString.indexOf(subject, uint8(bytes1("q")), 17), LibString.NOT_FOUND);
-        assertEq(
-            LibString.indexOf(subject, uint8(bytes1("q")), 17),
-            LibString.NOT_FOUND
-        );
-        assertEq(LibString.indexOf("abcabcabc", uint8(bytes1("a")), 0), 0);
-        assertEq(LibString.indexOf("abcabcabc", uint8(bytes1("a")), 1), 3);
+        assertEq(LibString.indexOfByte("", "a"), LibString.NOT_FOUND);
+        assertEq(LibString.indexOfByte("", "a", 1), LibString.NOT_FOUND);
+        assertEq(LibString.indexOfByte(subject, "a"), 0);
+        assertEq(LibString.indexOfByte(subject, "a", 1), LibString.NOT_FOUND);
+        assertEq(LibString.indexOfByte(subject, "b"), 1);
+        assertEq(LibString.indexOfByte(subject, "X"), 49);
+        assertEq(LibString.indexOfByte(subject, "q"), 16);
+        assertEq(LibString.indexOfByte(subject, "q", 16), 16);
+        assertEq(LibString.indexOfByte(subject, "q", 17), LibString.NOT_FOUND);
+        assertEq(LibString.indexOfByte(subject, "q", 17), LibString.NOT_FOUND);
+        assertEq(LibString.indexOfByte("abcabcabc", "a", 0), 0);
+        assertEq(LibString.indexOfByte("abcabcabc", "a", 1), 3);
     }
 
     function testStringLastIndexOf(uint256) public brutalizeMemory {

--- a/test/LibString.t.sol
+++ b/test/LibString.t.sol
@@ -636,6 +636,22 @@ contract LibStringTest is SoladyTest {
         assertEq(LibString.indexOf("a", "bcd", 0), LibString.NOT_FOUND);
         assertEq(LibString.indexOf("accd", "bcd"), LibString.NOT_FOUND);
         assertEq(LibString.indexOf("", "bcd"), LibString.NOT_FOUND);
+
+        assertEq(LibString.indexOf("", uint8(bytes1("a"))), LibString.NOT_FOUND);
+        assertEq(LibString.indexOf("", uint8(bytes1("a")), 1), LibString.NOT_FOUND);
+        assertEq(LibString.indexOf(subject, uint8(bytes1("a")), 0), 0);
+        assertEq(LibString.indexOf(subject, uint8(bytes1("a")), 1), LibString.NOT_FOUND);
+        assertEq(LibString.indexOf(subject, uint8(bytes1("b"))), 1);
+        assertEq(LibString.indexOf(subject, uint8(bytes1("X"))), 49);
+        assertEq(LibString.indexOf(subject, uint8(bytes1("q"))), 16);
+        assertEq(LibString.indexOf(subject, uint8(bytes1("q")), 16), 16);
+        assertEq(LibString.indexOf(subject, uint8(bytes1("q")), 17), LibString.NOT_FOUND);
+        assertEq(
+            LibString.indexOf(subject, uint8(bytes1("q")), 17),
+            LibString.NOT_FOUND
+        );
+        assertEq(LibString.indexOf("abcabcabc", uint8(bytes1("a")), 0), 0);
+        assertEq(LibString.indexOf("abcabcabc", uint8(bytes1("a")), 1), 3);
     }
 
     function testStringLastIndexOf(uint256) public brutalizeMemory {

--- a/test/LibString.t.sol
+++ b/test/LibString.t.sol
@@ -636,7 +636,27 @@ contract LibStringTest is SoladyTest {
         assertEq(LibString.indexOf("a", "bcd", 0), LibString.NOT_FOUND);
         assertEq(LibString.indexOf("accd", "bcd"), LibString.NOT_FOUND);
         assertEq(LibString.indexOf("", "bcd"), LibString.NOT_FOUND);
+    }
 
+    function testStringIndexOfByte(uint256) public brutalizeMemory {
+        string memory filler0 = _generateString("ABCDEFGHIJKLMNOPQRSTUVWXYZ");
+        string memory filler1 = _generateString("ABCDEFGHIJKLMNOPQRSTUVWXYZ");
+        bytes1 search = _generateByte("abcdefghijklmnopqrstuvwxyz");
+
+        string memory subject =
+            string(bytes.concat(bytes(filler0), abi.encodePacked(search), bytes(filler1)));
+
+        uint256 from = _generateFrom(subject);
+
+        if (from > bytes(filler0).length) {
+            assertEq(LibString.indexOfByte(subject, search, from), LibString.NOT_FOUND);
+        } else {
+            assertEq(LibString.indexOfByte(subject, search, from), bytes(filler0).length);
+        }
+    }
+
+    function testStringIndexOfByte() public {
+        string memory subject = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ";
         assertEq(LibString.indexOfByte("", "a"), LibString.NOT_FOUND);
         assertEq(LibString.indexOfByte("", "a", 1), LibString.NOT_FOUND);
         assertEq(LibString.indexOfByte(subject, "a"), 0);
@@ -1831,6 +1851,20 @@ contract LibStringTest is SoladyTest {
                         mload(add(add(byteChoices, 1), mod(keccak256(0x00, 0x40), mload(byteChoices))))
                     )
                 }
+            }
+        }
+    }
+
+    function _generateByte(string memory byteChoices) internal returns (bytes1 result) {
+        uint256 randomness = _random();
+        /// @solidity memory-safe-assembly
+        assembly {
+            if mload(byteChoices) {
+                mstore(0x00, randomness)
+                mstore(0x20, gas())
+                // forgefmt: disable-next-item
+                result := mload(add(add(byteChoices, 1), mod(keccak256(0x00, 0x40), mload(byteChoices))))
+                result := shl(248, result)
             }
         }
     }


### PR DESCRIPTION
## Description

Adds `function indexOfByte(bytes memory subject, bytes1 needle, uint256 from)` and offset-less shortcut to `LibBytes` and `LibString`.

This is a considerably more optimal version of `indexOf` in the case only a byte needle is used as we can apply some learnings from [bithacks](https://graphics.stanford.edu/~seander/bithacks.html) and keep the gas cost per 'missed' chunk quite low.

The reason for naming it `indexOfByte` versus keeping it as `indexOf` is because Solidity also tries to cast literal strings to `bytes1`, so if there's an implementation for `bytes` and one for `bytes1`, the user always has to be explicit on the type, which can get annoying.

Reproduced the `clz` implementation inside of it to avoid creating a dependency just for that and for a very small optimization, but it would be okay to do otherwise as well.

(Keeping it as draft for a review soon, and possibly some more tests.)

## Checklist

Ensure you completed **all of the steps** below before submitting your pull request:

- [x] Ran `forge fmt`?
- [x] Ran `forge test`?
