### PR TITLE
feat: added solx profile

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -33,6 +33,17 @@ evm_version = "cancun"
 odyssey = true
 skip = []
 
+[profile.solx]
+solc_version = "/usr/local/bin/solx"
+evm_version = "paris" # Cancun will be tested in the CI.
+optimization = 3
+gas_limit = 100_000_000 # ETH is 30M, but we use a higher value.
+skip = ["*/*7702*", "*/*Transient*", "*/ext/ithaca/*", "*/ext/zksync/*"]
+fs_permissions = [{ access = "read", path = "./test/data"}]
+remappings = [
+  "forge-std=test/utils/forge-std/"
+]
+
 [fmt]
 line_length = 100 # While we allow up to 120, we lint at 100 for readability.
 


### PR DESCRIPTION
## Description

Added a [solx](https://solx.zksync.io/) gas profile.

## Checklist

- [x] Ran `forge fmt`?
- [x] Ran `forge test`?

## Data

To compare solx to solc, you can do the following:

1. Install `solx` (docs: [solx](https://solx.zksync.io/))
2. Run `FOUNDRY_PROFILE=solx forge test --gas-report` and `forge test --gas-report` and compare the outputs

I have created a spreadsheet comparing if people would like to see:

As both a .csv or google sheets

- [gas_comparison.csv](https://github.com/user-attachments/files/20970661/gas_comparison.csv)
- [google sheets](https://docs.google.com/spreadsheets/d/1BT9V6rfQdVlidz6bEEZB_RFuqSpLSOR3A48uKYoj8CI/edit?usp=sharing)