### PR TITLE
🥢  ERC6551Proxy typo fix

### DIFF
--- a/src/accounts/ERC6551Proxy.sol
+++ b/src/accounts/ERC6551Proxy.sol
@@ -48,7 +48,7 @@ contract ERC6551Proxy {
         bytes32 implementation;
         /// @solidity memory-safe-assembly
         assembly {
-            mstore(0x40, returndatasize()) // Optimization trick to change `6040608052` into `3d604052`.
+            mstore(0x40, returndatasize()) // Optimization trick to change `6080604052` into `3d604052`.
             implementation := sload(_ERC1967_IMPLEMENTATION_SLOT)
         }
         if (implementation == bytes32(0)) {


### PR DESCRIPTION
## Description

Found a tiny typo in the `ERC6551Proxy` where the optimization to allocate scratch space for the free memory pointer is described. In the current code, `6040608052` is used, which translates to `mstore(0x80, 0x40)`. Changed it to `6080604052`.

This is a super nit-picky one. Hope to provide a much more decent contribution in the future.

## Checklist

Ensure you completed **all of the steps** below before submitting your pull request:

- [x] Ran `forge fmt`?
- [x] Ran `forge test`?

_Pull requests with an incomplete checklist will be thrown out._

<!--     Emoji Table:     -->
<!-- readme/docs       📝 -->
<!-- new feature       ✨ -->
<!-- refactor/cleanup  ♻️ -->
<!-- nit               🥢 -->
<!-- security fix      🔒 -->
<!-- optimization      ⚡️ -->
<!-- configuration     👷‍♂️ -->
<!-- events            🔊 -->
<!-- bug fix           🐞 -->
