### PR TITLE
📝 Correct erc20.md links in weth.md

### DIFF
--- a/docs/tokens/weth.md
+++ b/docs/tokens/weth.md
@@ -7,7 +7,7 @@ Simple Wrapped Ether implementation.
 
 <b>Inherits:</b>  
 
-- [`tokens/ERC20.sol`](tokens/erc20.md)  
+- [`ERC20.sol`](erc20.md)  
 
 
 <!-- customintro:start --><!-- customintro:end -->


### PR DESCRIPTION
Remove incorrect "tokens/" prefix from relative links since both files 
are in the same directory.