### PR TITLE
⚡️ Optimize Pow2 Padding

### DIFF
--- a/src/utils/MerkleTreeLib.sol
+++ b/src/utils/MerkleTreeLib.sol
@@ -254,6 +254,7 @@ library MerkleTreeLib {
         pure
         returns (bytes32[] memory result)
     {
+        uint256 p = roundUpPow2(leaves.length);
         /// @solidity memory-safe-assembly
         assembly {
             result := mload(0x40)
@@ -262,8 +263,6 @@ library MerkleTreeLib {
                 mstore(0x00, 0xe7171dc4) // `MerkleTreeLeavesEmpty()`.
                 revert(0x1c, 0x04)
             }
-            let p := 1 // Padded length.
-            for {} lt(p, l) {} { p := add(p, p) }
             mstore(result, p) // Store length.
             mstore(0x40, add(result, add(0x20, shl(5, p)))) // Allocate memory.
             let d := sub(result, leaves)
@@ -281,5 +280,23 @@ library MerkleTreeLib {
     /// @dev Equivalent to `pad(leaves, bytes32(0))`.
     function pad(bytes32[] memory leaves) internal pure returns (bytes32[] memory result) {
         result = pad(leaves, bytes32(0));
+    }
+
+    /// @dev Returns the smallest power of 2 greater than or equal to `x`.
+    /// Defaults to zero if `x == 0`.
+    function roundUpPow2(uint256 x) internal pure returns (uint256 y) {
+        /// @solidity memory-safe-assembly
+        assembly {
+            y := sub(x, 1)
+            y := or(y, shr(1, y))
+            y := or(y, shr(2, y))
+            y := or(y, shr(4, y))
+            y := or(y, shr(8, y))
+            y := or(y, shr(16, y))
+            y := or(y, shr(32, y))
+            y := or(y, shr(64, y))
+            y := or(y, shr(128, y))
+            y := add(y, 1)
+        }
     }
 }


### PR DESCRIPTION
## Description

⚡️ Replace iterative `roundUpPow2` calculation with a constant-time bit-twiddling version inspired by [“Bit Hacks” – Round up to next power of 2](https://graphics.stanford.edu/~seander/bithacks.html#RoundUpPowerOf2).

`O(log(n)) -> O(1)`

## Checklist

Ensure you completed **all of the steps** below before submitting your pull request:

- [x] Ran `forge fmt`?
- [x] Ran `forge test`?

_Pull requests with an incomplete checklist will be thrown out._

<!--     Emoji Table:     -->
<!-- readme/docs       📝 -->
<!-- new feature       ✨ -->
<!-- refactor/cleanup  ♻️ -->
<!-- nit               🥢 -->
<!-- security fix      🔒 -->
<!-- optimization      ⚡️ -->
<!-- configuration     👷‍♂️ -->
<!-- events            🔊 -->
<!-- bug fix           🐞 -->
