### PR TITLE
fix: correct relative paths in token documentation links

### DIFF
--- a/docs/tokens/erc4626.md
+++ b/docs/tokens/erc4626.md
@@ -7,7 +7,7 @@ Simple ERC4626 tokenized Vault implementation.
 
 <b>Inherits:</b>  
 
-- [`tokens/ERC20.sol`](tokens/erc20.md)  
+- [`tokens/ERC20.sol`](erc20.md)  
 
 
 <!-- customintro:start --><!-- customintro:end -->

--- a/docs/tokens/weth.md
+++ b/docs/tokens/weth.md
@@ -7,7 +7,7 @@ Simple Wrapped Ether implementation.
 
 <b>Inherits:</b>  
 
-- [`tokens/ERC20.sol`](tokens/erc20.md)  
+- [`tokens/ERC20.sol`](erc20.md)  
 
 
 <!-- customintro:start --><!-- customintro:end -->


### PR DESCRIPTION
Fix relative paths in token docs: change 'tokens/erc20.md' to 'erc20.md'