### PR TITLE
✨ verifyBlockHash + leadingPos

### DIFF
--- a/src/utils/BlockHashLib.sol
+++ b/src/utils/BlockHashLib.sol
@@ -6,12 +6,29 @@ pragma solidity ^0.8.4;
 /// @author Modified from OpenZeppelin (https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/contracts/utils/Blockhash.sol)
 library BlockHashLib {
     /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
+    /*                       CUSTOM ERRORS                        */
+    /*.•°:°.´+˚.*°.˚:*.´•*.+°.•°:´*.´•*.•°.•°:°.´:•˚°.*°.˚:*.´+°.•*/
+
+    /// @dev Invalid block hash.
+    error InvalidBlockHeader();
+
+    /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
     /*                         CONSTANTS                          */
     /*.•°:°.´+˚.*°.˚:*.´•*.+°.•°:´*.´•*.•°.•°:°.´:•˚°.*°.˚:*.´+°.•*/
 
     /// @dev Address of the EIP-2935 history storage contract.
     /// See: https://eips.ethereum.org/EIPS/eip-2935
     address internal constant HISTORY_STORAGE_ADDRESS = 0x0000F90827F1C53a10cb7A02335B175320002935;
+
+    /// @dev Table of leading block header fields (indices 0-6), each entry is 20 bits: [12 bits: field length][8 bits: starting position]
+    ///   0: parentHash          - starts = 1,   length 32 bytes
+    ///   1: ommersHash        - starts = 34,  length 32 bytes (Now constant `Keccak256(RLP())`)
+    ///   2: beneficiary          - starts = 67,  length 20 bytes
+    ///   3: stateRoot            - starts = 88,  length 32 bytes
+    ///   4: transactionsRoot  - starts = 121, length 32 bytes
+    ///   5: receiptsRoot        - starts = 154, length 32 bytes
+    ///   6: logsBloom           - starts = 189, length 256 bytes
+    uint256 internal constant LEADING_FIELDS_POS_TABLE = 0x100bd0209a0207902058014430202202001;
 
     /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
     /*                         OPERATIONS                         */
@@ -33,6 +50,43 @@ library BlockHashLib {
             mstore(0x00, 0)
             pop(staticcall(gas(), HISTORY_STORAGE_ADDRESS, 0x20, 0x20, 0x00, 0x20))
             result := mload(0x00)
+        }
+    }
+
+    /// @dev Returns whether the hash of a provided RLP-encoded block `header` equals the block hash at `blockNumber`.
+    function verifyBlockHeader(bytes calldata header, uint256 blockNumber)
+        internal
+        view
+        returns (bytes32 result)
+    {
+        result = blockHash(blockNumber);
+        /// @solidity memory-safe-assembly
+        assembly {
+            calldatacopy(mload(0x40), header.offset, header.length)
+            if xor(result, keccak256(mload(0x40), header.length)) {
+                mstore(0x00, 0x464db2f8) // InvalidBlockHeader()
+                revert(0x1c, 0x04)
+            }
+        }
+    }
+
+    /// @dev Retrieves the position of a leading field (field indices 0-6) from an RLP-encoded block header.
+    /// Leading fields are always present and have fixed sizes and lengths.
+    /// This function allows efficient extraction of these fields from calldata without full RLP decoding.
+    /// For the specification of field order and sizes, please refer to p. 6 of the Ethereum Yellow Paper:
+    /// (https://ethereum.github.io/yellowpaper/paper.pdf)
+    function leadingPos(bytes calldata header, uint256 field)
+        internal
+        pure
+        returns (uint256 start, uint256 length)
+    {
+        /// @solidity memory-safe-assembly
+        assembly {
+            let prefix := sub(byte(0, calldataload(header.offset)), 0xF6)
+            let pos :=
+                mul(and(0xFFFFF, shr(mul(0x14, field), LEADING_FIELDS_POS_TABLE)), lt(field, 0x7))
+            start := add(and(0xFF, pos), prefix)
+            length := shr(0x8, pos)
         }
     }
 }

--- a/src/utils/BlockHashLib.sol
+++ b/src/utils/BlockHashLib.sol
@@ -54,7 +54,7 @@ library BlockHashLib {
     }
 
     /// @dev Returns whether the hash of a provided RLP-encoded block `header` equals the block hash at `blockNumber`.
-    function verifyBlockHeader(bytes calldata header, uint256 blockNumber)
+    function verifyBlockHash(bytes calldata header, uint256 blockNumber)
         internal
         view
         returns (bytes32 result)
@@ -63,7 +63,7 @@ library BlockHashLib {
         /// @solidity memory-safe-assembly
         assembly {
             calldatacopy(mload(0x40), header.offset, header.length)
-            if xor(result, keccak256(mload(0x40), header.length)) {
+            if iszero(eq(result, keccak256(mload(0x40), header.length))) {
                 mstore(0x00, 0x464db2f8) // InvalidBlockHeader()
                 revert(0x1c, 0x04)
             }

--- a/src/utils/BlockHashLib.sol
+++ b/src/utils/BlockHashLib.sol
@@ -82,7 +82,7 @@ library BlockHashLib {
     {
         /// @solidity memory-safe-assembly
         assembly {
-            let prefix := sub(byte(0, calldataload(header.offset)), 0xF6)
+            let prefix := sub(byte(0, calldataload(header.offset)), 0xF6) // List prefix
             let pos :=
                 mul(and(0xFFFFF, shr(mul(0x14, field), LEADING_FIELDS_POS_TABLE)), lt(field, 0x7))
             start := add(and(0xFF, pos), prefix)

--- a/test/BlockHashLib.t.sol
+++ b/test/BlockHashLib.t.sol
@@ -72,10 +72,9 @@ contract BlockHashLibTest is SoladyTest {
             cd = new bytes[](1);
             cd[0] = abi.encodeWithSelector(this.checkLeadingPos.selector, _ETH_BLOCK_23270177);
         }
-        if (selector == this.testVerifyBlockHeader.selector) {
+        if (selector == this.testVerifyBlockHash.selector) {
             cd = new bytes[](1);
-            cd[0] =
-                abi.encodeWithSelector(this.checkVerifyBlockHeader.selector, _ETH_BLOCK_23270177);
+            cd[0] = abi.encodeWithSelector(this.checkVerifyBlockHash.selector, _ETH_BLOCK_23270177);
         }
     }
 
@@ -142,13 +141,13 @@ contract BlockHashLibTest is SoladyTest {
         }
     }
 
-    function checkVerifyBlockHeader(bytes calldata h) public {
+    function checkVerifyBlockHash(bytes calldata h) public {
         vm.roll(23270177 + 1);
         vm.setBlockhash(23270177, _ETH_BLOCK_HASH_23270177);
-        assertEq(BlockHashLib.verifyBlockHeader(h, 23270177), _ETH_BLOCK_HASH_23270177);
+        assertEq(BlockHashLib.verifyBlockHash(h, 23270177), _ETH_BLOCK_HASH_23270177);
     }
 
     function testLeadingPos() public view {}
 
-    function testVerifyBlockHeader() public view {}
+    function testVerifyBlockHash() public view {}
 }

--- a/test/BlockHashLib.t.sol
+++ b/test/BlockHashLib.t.sol
@@ -72,6 +72,11 @@ contract BlockHashLibTest is SoladyTest {
             cd = new bytes[](1);
             cd[0] = abi.encodeWithSelector(this.checkLeadingPos.selector, _ETH_BLOCK_23270177);
         }
+        if (selector == this.testVerifyBlockHeader.selector) {
+            cd = new bytes[](1);
+            cd[0] =
+                abi.encodeWithSelector(this.checkVerifyBlockHeader.selector, _ETH_BLOCK_23270177);
+        }
     }
 
     function checkLeadingPos(bytes calldata h) public {
@@ -137,5 +142,13 @@ contract BlockHashLibTest is SoladyTest {
         }
     }
 
+    function checkVerifyBlockHeader(bytes calldata h) public {
+        vm.roll(23270177 + 1);
+        vm.setBlockhash(23270177, _ETH_BLOCK_HASH_23270177);
+        assertEq(BlockHashLib.verifyBlockHeader(h, 23270177), _ETH_BLOCK_HASH_23270177);
+    }
+
     function testLeadingPos() public view {}
+
+    function testVerifyBlockHeader() public view {}
 }


### PR DESCRIPTION
## Description

Adds minimal block header verification utilities for light client implementations.

- Added `BlockHashLib.verifyBlockHash(blockHeader, blockNumber)`
Validates RLP-encoded headers against `BlockHashLib.blockHash(blockNumber)`.

- Added BlockHashLib.leadingPos(blockHeader, fieldIndex):
Constant time leading field extraction using packed lookup table, without full RLP-decoding.

## Checklist

Ensure you completed **all of the steps** below before submitting your pull request:

- [x] Ran `forge fmt`?
- [x] Ran `forge test`?

_Pull requests with an incomplete checklist will be thrown out._

<!--     Emoji Table:     -->
<!-- readme/docs       📝 -->
<!-- new feature       ✨ -->
<!-- refactor/cleanup  ♻️ -->
<!-- nit               🥢 -->
<!-- security fix      🔒 -->
<!-- optimization      ⚡️ -->
<!-- configuration     👷‍♂️ -->
<!-- events            🔊 -->
<!-- bug fix           🐞 -->
