### PR TITLE
✨ Add new calldata optimal execution mode for ERC7821

### DIFF
--- a/src/accounts/ERC7821.sol
+++ b/src/accounts/ERC7821.sol
@@ -264,6 +264,9 @@ contract ERC7821 is Receiver {
     function _execute(CallSansTo[] calldata calls, address to, bytes32 keyHash) internal virtual {
         unchecked {
             uint256 i;
+            if (to == address(0)) {
+                to = address(this);
+            }
             if (calls.length == uint256(0)) return;
             do {
                 (uint256 value, bytes calldata data) = _get(calls, i);

--- a/src/accounts/ERC7821.sol
+++ b/src/accounts/ERC7821.sol
@@ -274,8 +274,11 @@ contract ERC7821 is Receiver {
     function _execute(CallSansTo[] calldata calls, address to, bytes32 keyHash) internal virtual {
         unchecked {
             uint256 i;
-            if (to == address(0)) {
-                to = address(this);
+            // If `to` is address(0), it will be replaced with address(this)
+            /// @solidity memory-safe-assembly
+            assembly {
+                let t := shr(96, shl(96, to))
+                to := or(mul(address(), iszero(t)), t)
             }
             if (calls.length == uint256(0)) return;
             do {

--- a/src/accounts/ERC7821.sol
+++ b/src/accounts/ERC7821.sol
@@ -137,13 +137,16 @@ contract ERC7821 is Receiver {
         }
     }
 
+    /// @dev For execution of a batch of batches with a common `to` address.
+    /// @dev if to == address(0), it will be replaced with address(this)
+    /// Execution Data: abi.encode(address to, CallSansTo[] calls, bytes opData)
     function _executeBatchCommonTo(bytes32 mode, bytes calldata executionData) internal virtual {
-        // Execution Data: abi.encode(address to, CallSansTo[] calls, bytes opData)
         address to;
         CallSansTo[] calldata calls;
         bytes calldata opData;
 
-        assembly ("memory-safe") {
+        /// @solidity memory-safe-assembly
+        assembly {
             to := calldataload(executionData.offset)
 
             let callOffset :=

--- a/src/accounts/ERC7821.sol
+++ b/src/accounts/ERC7821.sol
@@ -60,6 +60,7 @@ contract ERC7821 is Receiver {
     /// - `0x01000000000000000000...`: Single batch. Does not support optional `opData`.
     /// - `0x01000000000078210001...`: Single batch. Supports optional `opData`.
     /// - `0x01000000000078210002...`: Batch of batches.
+    /// - `0x01000000000078210003...`: Single batch with common `to` address and optional `opData`.
     ///
     /// For the "batch of batches" mode, each batch will be recursively passed into
     /// `execute` internally with mode `0x01000000000078210001...`.
@@ -230,6 +231,9 @@ contract ERC7821 is Receiver {
         revert(); // In your override, replace this with logic to operate on `opData`.
     }
 
+    /// @dev Executes the calls.
+    /// Reverts and bubbles up error if any call fails.
+    /// The `mode` and `executionData` are passed along in case there's a need to use them.
     function _execute(
         bytes32 mode,
         bytes calldata executionData,
@@ -264,6 +268,9 @@ contract ERC7821 is Receiver {
         }
     }
 
+    /// @dev Executes the calls.
+    /// Reverts and bubbles up error if any call fails.
+    /// `extraData` can be any supplementary data (e.g. a memory pointer, some hash).
     function _execute(CallSansTo[] calldata calls, address to, bytes32 keyHash) internal virtual {
         unchecked {
             uint256 i;
@@ -298,6 +305,7 @@ contract ERC7821 is Receiver {
         }
     }
 
+    /// @dev Convenience function for getting `calls[i]`, without bounds checks.
     function _get(CallSansTo[] calldata calls, uint256 i)
         internal
         view

--- a/test/ERC7821.t.sol
+++ b/test/ERC7821.t.sol
@@ -275,4 +275,18 @@ contract ERC7821Test is SoladyTest {
     function pushBytes(bytes memory x) public {
         _bytes.push(x);
     }
+
+    function testERC7821CommonToWithZeroAddress() public {
+        // Test that when to=address(0), it gets replaced with address(this) (the MockERC7821 contract)
+        // We'll call executeDirect which directly calls the internal _execute function
+        ERC7821.CallSansTo[] memory calls = new ERC7821.CallSansTo[](1);
+        calls[0].value = 0;
+        calls[0].data = abi.encodeWithSignature("setAuthorizedCaller(address,bool)", address(0x123), true);
+
+        // This should replace address(0) with address(mbe) and call setAuthorizedCaller on itself
+        mbe.executeDirect(calls, address(0));
+
+        // Verify the call succeeded by checking that address(0x123) is now authorized
+        assertTrue(mbe.isAuthorizedCaller(address(0x123)));
+    }
 }

--- a/test/ERC7821.t.sol
+++ b/test/ERC7821.t.sol
@@ -13,7 +13,7 @@ contract ERC7821Test is SoladyTest {
     address target;
 
     bytes32 internal constant _SUPPORTED_MODE = bytes10(0x01000000000078210001);
-
+    bytes32 internal constant _COMMON_TO_MODE = bytes10(0x01000000000078210003);
     bytes[] internal _bytes;
 
     function setUp() public {
@@ -54,6 +54,24 @@ contract ERC7821Test is SoladyTest {
         mbe.execute{value: _totalValue(calls)}(_SUPPORTED_MODE, data);
     }
 
+    function testERC7821CommonToGas() public {
+        vm.pauseGasMetering();
+        vm.deal(address(this), 1 ether);
+
+        ERC7821.CallSansTo[] memory calls = new ERC7821.CallSansTo[](2);
+
+        calls[0].value = 123;
+        calls[0].data = abi.encodeWithSignature("returnsBytes(bytes)", "hehe");
+
+        calls[1].value = 789;
+        calls[1].data = abi.encodeWithSignature("returnsHash(bytes)", "lol");
+
+        bytes memory data = abi.encode(target, calls);
+        vm.resumeGasMetering();
+
+        mbe.execute{value: _totalValue(calls)}(_COMMON_TO_MODE, data);
+    }
+
     function testERC7821(bytes memory opData) public {
         vm.deal(address(this), 1 ether);
 
@@ -72,6 +90,23 @@ contract ERC7821Test is SoladyTest {
         assertEq(mbe.lastOpData(), opData);
     }
 
+    function testERC7821CommonTo(bytes memory opData) public {
+        vm.deal(address(this), 1 ether);
+
+        ERC7821.CallSansTo[] memory calls = new ERC7821.CallSansTo[](2);
+        calls[0].value = 123;
+        calls[0].data = abi.encodeWithSignature("returnsBytes(bytes)", "hehe");
+
+        calls[1].value = 789;
+        calls[1].data = abi.encodeWithSignature("returnsHash(bytes)", "lol");
+
+        mbe.execute{value: _totalValue(calls)}(
+            _COMMON_TO_MODE, _encodeCommonTo(target, calls, opData)
+        );
+
+        assertEq(mbe.lastOpData(), opData);
+    }
+
     function testERC7821ForRevert() public {
         ERC7821.Call[] memory calls = new ERC7821.Call[](1);
         calls[0].to = target;
@@ -82,12 +117,29 @@ contract ERC7821Test is SoladyTest {
         mbe.execute{value: _totalValue(calls)}(_SUPPORTED_MODE, _encode(calls, ""));
     }
 
+    function testERC7821CommonToForRevert() public {
+        ERC7821.CallSansTo[] memory calls = new ERC7821.CallSansTo[](1);
+        calls[0].value = 0;
+        calls[0].data = abi.encodeWithSignature("revertsWithCustomError()");
+
+        vm.expectRevert(CustomError.selector);
+        mbe.execute{value: _totalValue(calls)}(_COMMON_TO_MODE, _encodeCommonTo(target, calls, ""));
+    }
+
     function _encode(ERC7821.Call[] memory calls, bytes memory opData)
         internal
         returns (bytes memory)
     {
         if (_randomChance(2) && opData.length == 0) return abi.encode(calls);
         return abi.encode(calls, opData);
+    }
+
+    function _encodeCommonTo(address to, ERC7821.CallSansTo[] memory calls, bytes memory opData)
+        internal
+        returns (bytes memory)
+    {
+        if (_randomChance(2) && opData.length == 0) return abi.encode(to, calls);
+        return abi.encode(to, calls, opData);
     }
 
     struct Payload {
@@ -125,7 +177,48 @@ contract ERC7821Test is SoladyTest {
         }
     }
 
+    function testERC7821CommonTo(bytes32) public {
+        vm.deal(address(this), 1 ether);
+
+        ERC7821.CallSansTo[] memory calls = new ERC7821.CallSansTo[](_randomUniform() & 3);
+        Payload[] memory payloads = new Payload[](calls.length);
+
+        for (uint256 i; i < calls.length; ++i) {
+            calls[i].value = _randomUniform() & 0xff;
+            bytes memory data = _truncateBytes(_randomBytes(), 0x1ff);
+            payloads[i].data = data;
+            if (_randomChance(2)) {
+                payloads[i].mode = 0;
+                calls[i].data = abi.encodeWithSignature("returnsBytes(bytes)", data);
+            } else {
+                payloads[i].mode = 1;
+                calls[i].data = abi.encodeWithSignature("returnsHash(bytes)", data);
+            }
+        }
+
+        mbe.executeDirect{value: _totalValue(calls)}(calls, target);
+
+        if (calls.length != 0 && _randomChance(32)) {
+            calls[_randomUniform() % calls.length].data =
+                abi.encodeWithSignature("revertsWithCustomError()");
+            vm.expectRevert(CustomError.selector);
+            mbe.executeDirect{value: _totalValue(calls)}(calls, target);
+        }
+    }
+
     function _totalValue(ERC7821.Call[] memory calls) internal pure returns (uint256 result) {
+        unchecked {
+            for (uint256 i; i < calls.length; ++i) {
+                result += calls[i].value;
+            }
+        }
+    }
+
+    function _totalValue(ERC7821.CallSansTo[] memory calls)
+        internal
+        pure
+        returns (uint256 result)
+    {
         unchecked {
             for (uint256 i; i < calls.length; ++i) {
                 result += calls[i].value;

--- a/test/ERC7821.t.sol
+++ b/test/ERC7821.t.sol
@@ -58,12 +58,12 @@ contract ERC7821Test is SoladyTest {
         vm.pauseGasMetering();
         vm.deal(address(this), 1 ether);
 
-        bytes[] memory datas = new bytes[](2);
+        bytes[] memory dataArr = new bytes[](2);
 
-        datas[0] = abi.encodeWithSignature("returnsBytes(bytes)", "hehe");
-        datas[1] = abi.encodeWithSignature("returnsHash(bytes)", "lol");
+        dataArr[0] = abi.encodeWithSignature("returnsBytes(bytes)", "hehe");
+        dataArr[1] = abi.encodeWithSignature("returnsHash(bytes)", "lol");
 
-        bytes memory data = abi.encode(target, datas);
+        bytes memory data = abi.encode(target, dataArr);
         vm.resumeGasMetering();
 
         mbe.execute(_CALLDATA_OPTIMAL_MODE, data);
@@ -90,11 +90,11 @@ contract ERC7821Test is SoladyTest {
     function testERC7821CalldataOptimal(bytes memory opData) public {
         vm.deal(address(this), 1 ether);
 
-        bytes[] memory datas = new bytes[](2);
-        datas[0] = abi.encodeWithSignature("returnsBytes(bytes)", "hehe");
-        datas[1] = abi.encodeWithSignature("returnsHash(bytes)", "lol");
+        bytes[] memory dataArr = new bytes[](2);
+        dataArr[0] = abi.encodeWithSignature("returnsBytes(bytes)", "hehe");
+        dataArr[1] = abi.encodeWithSignature("returnsHash(bytes)", "lol");
 
-        mbe.execute(_CALLDATA_OPTIMAL_MODE, _encodeCalldataOptimal(target, datas, opData));
+        mbe.execute(_CALLDATA_OPTIMAL_MODE, _encodeCalldataOptimal(target, dataArr, opData));
 
         assertEq(mbe.lastOpData(), opData);
     }
@@ -110,11 +110,11 @@ contract ERC7821Test is SoladyTest {
     }
 
     function testERC7821CalldataOptimalForRevert() public {
-        bytes[] memory datas = new bytes[](1);
-        datas[0] = abi.encodeWithSignature("revertsWithCustomError()");
+        bytes[] memory dataArr = new bytes[](1);
+        dataArr[0] = abi.encodeWithSignature("revertsWithCustomError()");
 
         vm.expectRevert(CustomError.selector);
-        mbe.execute(_CALLDATA_OPTIMAL_MODE, _encodeCalldataOptimal(target, datas, ""));
+        mbe.execute(_CALLDATA_OPTIMAL_MODE, _encodeCalldataOptimal(target, dataArr, ""));
     }
 
     function _encode(ERC7821.Call[] memory calls, bytes memory opData)
@@ -125,12 +125,12 @@ contract ERC7821Test is SoladyTest {
         return abi.encode(calls, opData);
     }
 
-    function _encodeCalldataOptimal(address to, bytes[] memory datas, bytes memory opData)
+    function _encodeCalldataOptimal(address to, bytes[] memory dataArr, bytes memory opData)
         internal
         returns (bytes memory)
     {
-        if (_randomChance(2) && opData.length == 0) return abi.encode(to, datas);
-        return abi.encode(to, datas, opData);
+        if (_randomChance(2) && opData.length == 0) return abi.encode(to, dataArr);
+        return abi.encode(to, dataArr, opData);
     }
 
     struct Payload {
@@ -171,28 +171,28 @@ contract ERC7821Test is SoladyTest {
     function testERC7821CalldataOptimal(bytes32) public {
         vm.deal(address(this), 1 ether);
 
-        bytes[] memory datas = new bytes[](_randomUniform() & 3);
-        Payload[] memory payloads = new Payload[](datas.length);
+        bytes[] memory dataArr = new bytes[](_randomUniform() & 3);
+        Payload[] memory payloads = new Payload[](dataArr.length);
 
-        for (uint256 i; i < datas.length; ++i) {
+        for (uint256 i; i < dataArr.length; ++i) {
             bytes memory data = _truncateBytes(_randomBytes(), 0x1ff);
             payloads[i].data = data;
             if (_randomChance(2)) {
                 payloads[i].mode = 0;
-                datas[i] = abi.encodeWithSignature("returnsBytes(bytes)", data);
+                dataArr[i] = abi.encodeWithSignature("returnsBytes(bytes)", data);
             } else {
                 payloads[i].mode = 1;
-                datas[i] = abi.encodeWithSignature("returnsHash(bytes)", data);
+                dataArr[i] = abi.encodeWithSignature("returnsHash(bytes)", data);
             }
         }
 
-        mbe.executeDirect(datas, target);
+        mbe.executeDirect(dataArr, target);
 
-        if (datas.length != 0 && _randomChance(32)) {
-            datas[_randomUniform() % datas.length] =
+        if (dataArr.length != 0 && _randomChance(32)) {
+            dataArr[_randomUniform() % dataArr.length] =
                 abi.encodeWithSignature("revertsWithCustomError()");
             vm.expectRevert(CustomError.selector);
-            mbe.executeDirect(datas, target);
+            mbe.executeDirect(dataArr, target);
         }
     }
 
@@ -258,11 +258,11 @@ contract ERC7821Test is SoladyTest {
     function testERC7821CalldataOptimalWithZeroAddress() public {
         // Test that when to=address(0), it gets replaced with address(this) (the MockERC7821 contract)
         // We'll call executeDirect which directly calls the internal _execute function
-        bytes[] memory datas = new bytes[](1);
-        datas[0] = abi.encodeWithSignature("setAuthorizedCaller(address,bool)", address(0x123), true);
+        bytes[] memory dataArr = new bytes[](1);
+        dataArr[0] = abi.encodeWithSignature("setAuthorizedCaller(address,bool)", address(0x123), true);
 
         // This should replace address(0) with address(mbe) and call setAuthorizedCaller on itself
-        mbe.executeDirect(datas, address(0));
+        mbe.executeDirect(dataArr, address(0));
 
         // Verify the call succeeded by checking that address(0x123) is now authorized
         assertTrue(mbe.isAuthorizedCaller(address(0x123)));

--- a/test/utils/mocks/MockERC7821.sol
+++ b/test/utils/mocks/MockERC7821.sol
@@ -26,11 +26,11 @@ contract MockERC7821 is ERC7821, Brutalizer {
         bytes32,
         bytes calldata,
         address to,
-        CallSansTo[] calldata calls,
+        bytes[] calldata datas,
         bytes calldata opData
     ) internal virtual override {
         lastOpData = opData;
-        _execute(calls, to, bytes32(0));
+        _execute(datas, to, bytes32(0));
     }
 
     function execute(bytes32 mode, bytes calldata executionData) public payable virtual override {
@@ -45,10 +45,10 @@ contract MockERC7821 is ERC7821, Brutalizer {
         _checkMemory();
     }
 
-    function executeDirect(CallSansTo[] calldata calls, address to) public payable virtual {
+    function executeDirect(bytes[] calldata datas, address to) public payable virtual {
         _misalignFreeMemoryPointer();
         _brutalizeMemory();
-        _execute(calls, to, bytes32(0));
+        _execute(datas, to, bytes32(0));
         _checkMemory();
     }
 

--- a/test/utils/mocks/MockERC7821.sol
+++ b/test/utils/mocks/MockERC7821.sol
@@ -26,11 +26,11 @@ contract MockERC7821 is ERC7821, Brutalizer {
         bytes32,
         bytes calldata,
         address to,
-        bytes[] calldata datas,
+        bytes[] calldata dataArr,
         bytes calldata opData
     ) internal virtual override {
         lastOpData = opData;
-        _execute(datas, to, bytes32(0));
+        _execute(dataArr, to, bytes32(0));
     }
 
     function execute(bytes32 mode, bytes calldata executionData) public payable virtual override {
@@ -45,10 +45,10 @@ contract MockERC7821 is ERC7821, Brutalizer {
         _checkMemory();
     }
 
-    function executeDirect(bytes[] calldata datas, address to) public payable virtual {
+    function executeDirect(bytes[] calldata dataArr, address to) public payable virtual {
         _misalignFreeMemoryPointer();
         _brutalizeMemory();
-        _execute(datas, to, bytes32(0));
+        _execute(dataArr, to, bytes32(0));
         _checkMemory();
     }
 

--- a/test/utils/mocks/MockERC7821.sol
+++ b/test/utils/mocks/MockERC7821.sol
@@ -22,6 +22,17 @@ contract MockERC7821 is ERC7821, Brutalizer {
         _execute(calls, bytes32(0));
     }
 
+    function _execute(
+        bytes32,
+        bytes calldata,
+        address to,
+        CallSansTo[] calldata calls,
+        bytes calldata opData
+    ) internal virtual override {
+        lastOpData = opData;
+        _execute(calls, to, bytes32(0));
+    }
+
     function execute(bytes32 mode, bytes calldata executionData) public payable virtual override {
         if (!isAuthorizedCaller[msg.sender]) revert Unauthorized();
         super.execute(mode, executionData);
@@ -31,6 +42,13 @@ contract MockERC7821 is ERC7821, Brutalizer {
         _misalignFreeMemoryPointer();
         _brutalizeMemory();
         _execute(calls, bytes32(0));
+        _checkMemory();
+    }
+
+    function executeDirect(CallSansTo[] calldata calls, address to) public payable virtual {
+        _misalignFreeMemoryPointer();
+        _brutalizeMemory();
+        _execute(calls, to, bytes32(0));
         _checkMemory();
     }
 


### PR DESCRIPTION
## Description

The PR adds a new calldata optimized execution mode to ERC7821 which allows you to batch calls to the same target address, without sending the redundant "to" variable in each call.
It also removes the value field, and assumes it will be 0 for all the calls. This is usually true for most DeFi batches, because everything uses WETH.

Even if the `address(0)` optimization is used in calldata, for each call there is still a 4 gas overhead. 
With this PR, you can compress the calldata down to the theoretical optimal, this is specially useful when you want to do highly optimized self calls.

Note: The `address(0)` replacement is still available with the common `to` field passed.

## Checklist

Ensure you completed **all of the steps** below before submitting your pull request:

- [x] Ran `forge fmt`?
- [x] Ran `forge test`?

_Pull requests with an incomplete checklist will be thrown out._

<!--     Emoji Table:     -->
<!-- readme/docs       📝 -->
<!-- new feature       ✨ -->
<!-- refactor/cleanup  ♻️ -->
<!-- nit               🥢 -->
<!-- security fix      🔒 -->
<!-- optimization      ⚡️ -->
<!-- configuration     👷‍♂️ -->
<!-- events            🔊 -->
<!-- bug fix           🐞 -->
