### PR TITLE
🐞 Clear reentrancy flag properly on non-mainnet chains at ReentrancyGuardTransient

### DIFF
--- a/src/utils/ReentrancyGuardTransient.sol
+++ b/src/utils/ReentrancyGuardTransient.sol
@@ -71,7 +71,7 @@ abstract contract ReentrancyGuardTransient {
             } else {
                 /// @solidity memory-safe-assembly
                 assembly {
-                    sstore(s, s)
+                    sstore(s, 0)
                 }
             }
         } else {


### PR DESCRIPTION
## Description
Fixes critical bug in `ReentrancyGuardTransient.sol` where `sstore(s, s)` should be `sstore(s, 0)` in the cleanup logic (line 74).

**Impact:** This bug caused functions with `nonReentrant` modifier from `ReentrancyGuardTransient.sol` to become permanently unusable after the first call on non-mainnet chains, as the reentrancy flag was never properly cleared.

**Fix:** Changed `sstore(s, s)` to `sstore(s, 0)` to properly clear the reentrancy flag.

## Checklist
Ensure you completed **all of the steps** below before submitting your pull request:
- [x] Ran `forge fmt`?
- [x] Ran `forge test`?