### PR TITLE
📝  docs: fix type mismatch in `abi.decode` comparison

### DIFF
--- a/docs/utils/efficienthashlib.md
+++ b/docs/utils/efficienthashlib.md
@@ -544,7 +544,7 @@ function eq(bytes memory a, bytes32 b)
     returns (bool result)
 ```
 
-Returns `abi.decode(a, (bytes32)) == a`.
+Returns `abi.decode(a, (bytes32)) == b`.
 
 ## Byte Slice Hashing Operations
 


### PR DESCRIPTION
## Description

noticed that the comparison was incorrectly using the original `bytes` value against the decoded `bytes32`, which can never be true.
updated the code to compare the decoded value to the correct `bytes32` variable.
this ensures the logic now works as intended.

## Checklist

Ensure you completed **all of the steps** below before submitting your pull request:

- [ ] Ran `forge fmt`?
- [ ] Ran `forge test`?

📝 