### PR TITLE
ci: bump actions/checkout to v6

### DIFF
--- a/.github/workflows/ci-all-via-ir.yml
+++ b/.github/workflows/ci-all-via-ir.yml
@@ -13,7 +13,7 @@ jobs:
         profile: [via-ir-0,via-ir-1,via-ir-2,via-ir-3]
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1

--- a/.github/workflows/ci-invariant-intense.yml
+++ b/.github/workflows/ci-invariant-intense.yml
@@ -13,7 +13,7 @@ jobs:
         profile: [invariant-intense-0,invariant-intense-1,invariant-intense-2,invariant-intense-3]
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1

--- a/.github/workflows/ci-super-intense.yml
+++ b/.github/workflows/ci-super-intense.yml
@@ -13,7 +13,7 @@ jobs:
         profile: [super-intense-0,super-intense-1]
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1

--- a/.github/workflows/ci-wake.yml
+++ b/.github/workflows/ci-wake.yml
@@ -13,7 +13,7 @@ jobs:
         profile: [via-ir-off, via-ir-on]
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
       - name: Setup Wake
         uses: Ackee-Blockchain/wake-setup-action@0.1.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
       matrix:
         profile: [post-prague,post-prague-via-ir,solc-past-versions-0,solc-past-versions-1,via-ir,min-solc,min-solc-via-ir,intense]
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - name: Install Foundry Stable
         uses: foundry-rs/foundry-toolchain@v1
         with:
@@ -85,7 +85,7 @@ jobs:
       matrix:
         profile: [post-cancun,post-cancun-via-ir]
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - name: Install Foundry Stable
         uses: foundry-rs/foundry-toolchain@v1
         with:
@@ -108,7 +108,7 @@ jobs:
           - ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
       - name: Run codespell
         uses: codespell-project/actions-codespell@v2.0
         with:
@@ -126,7 +126,7 @@ jobs:
           - ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
         with:
@@ -150,7 +150,7 @@ jobs:
           - ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
         with:


### PR DESCRIPTION
Migrate workflows to checkout@v6 (Node 24 runtime). Min runner: v2.329.0.

https://github.com/actions/checkout/releases/tag/v6.0.0