### PR TITLE
chore: annual license year update

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2022-2025 Solady.
+Copyright (c) 2022-2026 Solady.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
Happy New Year!

## Changes
Updates the copyright year in license files from 2025 to 2026.

This is a routine annual update to keep the copyright notices current.