### PR TITLE
📝 fix NatSpec comment prefix in ERC1155 and ERC6909

### DIFF
--- a/src/tokens/ERC1155.sol
+++ b/src/tokens/ERC1155.sol
@@ -15,7 +15,7 @@ pragma solidity ^0.8.4;
 ///
 /// If you are overriding:
 /// - Make sure all variables written to storage are properly cleaned
-//    (e.g. the bool value for `isApprovedForAll` MUST be either 1 or 0 under the hood).
+///    (e.g. the bool value for `isApprovedForAll` MUST be either 1 or 0 under the hood).
 /// - Check that the overridden function is actually used in the function you want to
 ///   change the behavior of. Much of the code has been manually inlined for performance.
 abstract contract ERC1155 {

--- a/src/tokens/ERC6909.sol
+++ b/src/tokens/ERC6909.sol
@@ -12,7 +12,7 @@ pragma solidity ^0.8.4;
 ///
 /// If you are overriding:
 /// - Make sure all variables written to storage are properly cleaned
-//    (e.g. the bool value for `isOperator` MUST be either 1 or 0 under the hood).
+///    (e.g. the bool value for `isOperator` MUST be either 1 or 0 under the hood).
 /// - Check that the overridden function is actually used in the function you want to
 ///   change the behavior of. Much of the code has been manually inlined for performance.
 abstract contract ERC6909 {


### PR DESCRIPTION
## Summary

Two NatSpec continuation lines use `//` instead of `///`, so doc tooling (soldoc, natspec renderers) skips them. Both lines contain security guidance for overriders about storage variable cleanliness.

## Changes

- `src/tokens/ERC1155.sol:18` - `//` to `///` on the `isApprovedForAll` storage requirement
- `src/tokens/ERC6909.sol:15` - `//` to `///` on the `isOperator` storage requirement

## Checklist

- [x] `forge fmt` passes
- [x] `forge test` (no behavioral changes, comment-only fix)