### PR TITLE
Update balanceOf function documentation

### DIFF
--- a/src/utils/SafeTransferLib.sol
+++ b/src/utils/SafeTransferLib.sol
@@ -438,7 +438,7 @@ library SafeTransferLib {
     }
 
     /// @dev Returns the amount of ERC20 `token` owned by `account`.
-    /// Returns zero if the `token` does not exist.
+    /// Returns zero if the `token` reverts during execution, does not exist, or returns less than 32 bytes.
     function balanceOf(address token, address account) internal view returns (uint256 amount) {
         /// @solidity memory-safe-assembly
         assembly {


### PR DESCRIPTION


## Description

Clarify behavior of balanceOf function regarding token existence and execution. Currently it only describes returning zero if the token called does not exist but that is misleading for developers because it will also return zero if the address reverts during its execution or if the address returns less than 32 bytes. This PR adds those to the description of the function.

## Checklist

Ensure you completed **all of the steps** below before submitting your pull request:

- [X] Ran `forge fmt`?
- [X] Ran `forge test`?

_Pull requests with an incomplete checklist will be thrown out._

<!--     Emoji Table:     -->
<!-- readme/docs       📝 -->
<!-- new feature       ✨ -->
<!-- refactor/cleanup  ♻️ -->
<!-- nit               🥢 -->
<!-- security fix      🔒 -->
<!-- optimization      ⚡️ -->
<!-- configuration     👷‍♂️ -->
<!-- events            🔊 -->
<!-- bug fix           🐞 -->
