### PR TITLE
⚡️ Golf `cbrt` by using a small table for an even better initial estimate and removing another iteration

### DIFF
--- a/src/utils/clz/FixedPointMathLib.sol
+++ b/src/utils/clz/FixedPointMathLib.sol
@@ -808,7 +808,7 @@ library FixedPointMathLib {
             // 8-bit fixed-point multipliers `c`: 144/128, 181/128, and 229/128
             // are selected by `b mod 3` to balance each octave's worst-case
             // final error. This gives >98 bits of precision after only 5
-            // Newton-Raphson iterations. The `or(1, ...)` keeps z ≥ 1 when the
+            // Newton-Raphson iterations. The `or(..., 1)` keeps z ≥ 1 when the
             // shifted estimate is 0.
             let b := sub(255, clz(x))
             z := or(shr(7, shl(div(b, 3), byte(add(mod(b, 3), 29), 0x90b5e5))), 1)

--- a/src/utils/clz/FixedPointMathLib.sol
+++ b/src/utils/clz/FixedPointMathLib.sol
@@ -804,16 +804,16 @@ library FixedPointMathLib {
     function cbrt(uint256 x) internal pure returns (uint256 z) {
         /// @solidity memory-safe-assembly
         assembly {
-            // Initial guess z ≈ ∛(3/4) · 2𐞥 where q = ⌊(257 − clz(x)) / 3⌋. The
-            // multiplier 233/256 ≈ 0.909 ≈ ∛(3/4) balances the worst-case
-            // over/underestimate across each octave triplet (ε_over ≈ 0.445,
-            // ε_under ≈ −0.278), giving >85 bits of precision after 6 N-R
-            // iterations. The `add(..., 1)` term ensures z ≥ 1 when x > 0 (the
-            // `shr` can produce 0 for small `q`)
-            z := add(shr(8, shl(div(sub(257, clz(x)), 3), 233)), 1)
+            // Initial guess z ≈ c · 2𐞥 where b = ⌊log₂(x)⌋, q = ⌊b / 3⌋. The
+            // 8-bit fixed-point multipliers `c`: 144/128, 181/128, and 229/128
+            // are selected by `b mod 3` to balance each octave's worst-case
+            // final error. This gives >98 bits of precision after only 5
+            // Newton-Raphson iterations. The `or(1, ...)` keeps z ≥ 1 when the
+            // shifted estimate is 0.
+            let b := sub(255, clz(x))
+            z := or(shr(7, shl(div(b, 3), byte(add(mod(b, 3), 29), 0x90b5e5))), 1)
 
-            // 6 Newton-Raphson iterations.
-            z := div(add(add(div(x, mul(z, z)), z), z), 3)
+            // 5 Newton-Raphson iterations
             z := div(add(add(div(x, mul(z, z)), z), z), 3)
             z := div(add(add(div(x, mul(z, z)), z), z), 3)
             z := div(add(add(div(x, mul(z, z)), z), z), 3)


### PR DESCRIPTION
## Description

Following on #1515, improve the implementation of `cbrt` by using a small lookup table to seed the initial estimate based on the input octave. This allows us to remove 1 additional Newton-Raphson iteration, going down to 5.

This PR was initially authored by AI (codex and claude) and then reviewed, validated, and cleaned up by a human (me). The [formal proof of correctness](https://github.com/0xProject/0x-settler/pull/511) was fully AI-authored.

## Checklist

- [x] Ran `forge fmt`?
- [x] Ran `forge test`?