### PR TITLE
✨ Add TBytes32Stack to LibTransient (issue #1185)

### DIFF
--- a/src/utils/LibTransient.sol
+++ b/src/utils/LibTransient.sol
@@ -50,6 +50,12 @@ library LibTransient {
         uint256 _spacer;
     }
 
+    /// @dev Pointer struct to a `bytes32` value stack in transient storage.
+    /// Unlike `TStack`, this stack directly stores the `bytes32` values.
+    struct TBytes32Stack {
+        uint256 _spacer;
+    }
+
     /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
     /*                       CUSTOM ERRORS                        */
     /*.•°:°.´+˚.*°.˚:*.´•*.+°.•°:´*.´•*.•°.•°:°.´:•˚°.*°.˚:*.´+°.•*/
@@ -799,6 +805,100 @@ library LibTransient {
             }
             tstore(ptr.slot, sub(lastTopPtr, 0x100000000)) // Decrements by a stride.
             lastTopPtr := add(mul(_STACK_BASE_SALT, ptr.slot), lastTopPtr)
+        }
+    }
+
+    /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
+    /*                  BYTES32 STACK OPERATIONS                  */
+    /*.•°:°.´+˚.*°.˚:*.´•*.+°.•°:´*.´•*.•°.•°:°.´:•˚°.*°.˚:*.´+°.•*/
+
+    /// @dev Returns a pointer to a `bytes32` value stack in transient storage.
+    function tBytes32Stack(bytes32 tSlot) internal pure returns (TBytes32Stack storage ptr) {
+        /// @solidity memory-safe-assembly
+        assembly {
+            ptr.slot := tSlot
+        }
+    }
+
+    /// @dev Returns a pointer to a `bytes32` value stack in transient storage.
+    function tBytes32Stack(uint256 tSlot) internal pure returns (TBytes32Stack storage ptr) {
+        /// @solidity memory-safe-assembly
+        assembly {
+            ptr.slot := tSlot
+        }
+    }
+
+    /// @dev Returns the number of elements in the stack.
+    function size(TBytes32Stack storage ptr) internal view returns (uint256 result) {
+        /// @solidity memory-safe-assembly
+        assembly {
+            result := tload(ptr.slot)
+        }
+    }
+
+    /// @dev Pushes `value` onto the top of the stack.
+    /// The element for index `i` is stored at `salt * slot + ((i + 1) << 32)`.
+    /// The `1 << 32` stride mirrors `TStack`, keeping element slots clear of small base slots.
+    function push(TBytes32Stack storage ptr, bytes32 value) internal {
+        /// @solidity memory-safe-assembly
+        assembly {
+            let n := tload(ptr.slot) // The current number of elements.
+            // Store `value` at the element slot for index `n`, then increment the size.
+            tstore(add(mul(_STACK_BASE_SALT, ptr.slot), shl(32, add(n, 1))), value)
+            tstore(ptr.slot, add(n, 1))
+        }
+    }
+
+    /// @dev Returns the value at the top of the stack. Reverts if the stack is empty.
+    function top(TBytes32Stack storage ptr) internal view returns (bytes32 value) {
+        /// @solidity memory-safe-assembly
+        assembly {
+            let n := tload(ptr.slot)
+            if iszero(n) {
+                mstore(0x00, 0xbb704e21) // `StackIsEmpty()`.
+                revert(0x1c, 0x04)
+            }
+            // The top element is at index `n - 1`: `salt * slot + (n << 32)`.
+            value := tload(add(mul(_STACK_BASE_SALT, ptr.slot), shl(32, n)))
+        }
+    }
+
+    /// @dev Returns the value that is `i` positions from the top of the stack.
+    /// `i = 0` returns the top element. Reverts if `i >= size`.
+    function top(TBytes32Stack storage ptr, uint256 i) internal view returns (bytes32 value) {
+        /// @solidity memory-safe-assembly
+        assembly {
+            let n := tload(ptr.slot)
+            if iszero(gt(n, i)) {
+                mstore(0x00, 0xbb704e21) // `StackIsEmpty()`.
+                revert(0x1c, 0x04)
+            }
+            // The element is at index `n - 1 - i`: `salt * slot + ((n - i) << 32)`.
+            value := tload(add(mul(_STACK_BASE_SALT, ptr.slot), shl(32, sub(n, i))))
+        }
+    }
+
+    /// @dev Removes and returns the value at the top of the stack. Reverts if the stack is empty.
+    function pop(TBytes32Stack storage ptr) internal returns (bytes32 value) {
+        /// @solidity memory-safe-assembly
+        assembly {
+            let n := tload(ptr.slot)
+            if iszero(n) {
+                mstore(0x00, 0xbb704e21) // `StackIsEmpty()`.
+                revert(0x1c, 0x04)
+            }
+            // The top element is at index `n - 1`: `salt * slot + (n << 32)`.
+            value := tload(add(mul(_STACK_BASE_SALT, ptr.slot), shl(32, n)))
+            tstore(ptr.slot, sub(n, 1)) // Decrement the size.
+        }
+    }
+
+    /// @dev Clears the stack at `ptr`.
+    /// Note: Values are not zeroed out, but the size is reset to zero.
+    function clear(TBytes32Stack storage ptr) internal {
+        /// @solidity memory-safe-assembly
+        assembly {
+            tstore(ptr.slot, 0)
         }
     }
 

--- a/src/utils/g/LibTransient.sol
+++ b/src/utils/g/LibTransient.sol
@@ -44,6 +44,12 @@ struct TStack {
     uint256 _spacer;
 }
 
+/// @dev Pointer struct to a `bytes32` value stack in transient storage.
+/// Unlike `TStack`, this stack directly stores the `bytes32` values.
+struct TBytes32Stack {
+    uint256 _spacer;
+}
+
 using LibTransient for TUint256 global;
 using LibTransient for TInt256 global;
 using LibTransient for TBytes32 global;
@@ -51,6 +57,7 @@ using LibTransient for TAddress global;
 using LibTransient for TBool global;
 using LibTransient for TBytes global;
 using LibTransient for TStack global;
+using LibTransient for TBytes32Stack global;
 
 /// @notice Library for transient storage operations.
 /// @author Solady (https://github.com/vectorized/solady/blob/main/src/utils/g/LibTransient.sol)
@@ -809,6 +816,100 @@ library LibTransient {
             }
             tstore(ptr.slot, sub(lastTopPtr, 0x100000000)) // Decrements by a stride.
             lastTopPtr := add(mul(_STACK_BASE_SALT, ptr.slot), lastTopPtr)
+        }
+    }
+
+    /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
+    /*                  BYTES32 STACK OPERATIONS                  */
+    /*.•°:°.´+˚.*°.˚:*.´•*.+°.•°:´*.´•*.•°.•°:°.´:•˚°.*°.˚:*.´+°.•*/
+
+    /// @dev Returns a pointer to a `bytes32` value stack in transient storage.
+    function tBytes32Stack(bytes32 tSlot) internal pure returns (TBytes32Stack storage ptr) {
+        /// @solidity memory-safe-assembly
+        assembly {
+            ptr.slot := tSlot
+        }
+    }
+
+    /// @dev Returns a pointer to a `bytes32` value stack in transient storage.
+    function tBytes32Stack(uint256 tSlot) internal pure returns (TBytes32Stack storage ptr) {
+        /// @solidity memory-safe-assembly
+        assembly {
+            ptr.slot := tSlot
+        }
+    }
+
+    /// @dev Returns the number of elements in the stack.
+    function size(TBytes32Stack storage ptr) internal view returns (uint256 result) {
+        /// @solidity memory-safe-assembly
+        assembly {
+            result := tload(ptr.slot)
+        }
+    }
+
+    /// @dev Pushes `value` onto the top of the stack.
+    /// The element for index `i` is stored at `salt * slot + ((i + 1) << 32)`.
+    /// The `1 << 32` stride mirrors `TStack`, keeping element slots clear of small base slots.
+    function push(TBytes32Stack storage ptr, bytes32 value) internal {
+        /// @solidity memory-safe-assembly
+        assembly {
+            let n := tload(ptr.slot) // The current number of elements.
+            // Store `value` at the element slot for index `n`, then increment the size.
+            tstore(add(mul(_STACK_BASE_SALT, ptr.slot), shl(32, add(n, 1))), value)
+            tstore(ptr.slot, add(n, 1))
+        }
+    }
+
+    /// @dev Returns the value at the top of the stack. Reverts if the stack is empty.
+    function top(TBytes32Stack storage ptr) internal view returns (bytes32 value) {
+        /// @solidity memory-safe-assembly
+        assembly {
+            let n := tload(ptr.slot)
+            if iszero(n) {
+                mstore(0x00, 0xbb704e21) // `StackIsEmpty()`.
+                revert(0x1c, 0x04)
+            }
+            // The top element is at index `n - 1`: `salt * slot + (n << 32)`.
+            value := tload(add(mul(_STACK_BASE_SALT, ptr.slot), shl(32, n)))
+        }
+    }
+
+    /// @dev Returns the value that is `i` positions from the top of the stack.
+    /// `i = 0` returns the top element. Reverts if `i >= size`.
+    function top(TBytes32Stack storage ptr, uint256 i) internal view returns (bytes32 value) {
+        /// @solidity memory-safe-assembly
+        assembly {
+            let n := tload(ptr.slot)
+            if iszero(gt(n, i)) {
+                mstore(0x00, 0xbb704e21) // `StackIsEmpty()`.
+                revert(0x1c, 0x04)
+            }
+            // The element is at index `n - 1 - i`: `salt * slot + ((n - i) << 32)`.
+            value := tload(add(mul(_STACK_BASE_SALT, ptr.slot), shl(32, sub(n, i))))
+        }
+    }
+
+    /// @dev Removes and returns the value at the top of the stack. Reverts if the stack is empty.
+    function pop(TBytes32Stack storage ptr) internal returns (bytes32 value) {
+        /// @solidity memory-safe-assembly
+        assembly {
+            let n := tload(ptr.slot)
+            if iszero(n) {
+                mstore(0x00, 0xbb704e21) // `StackIsEmpty()`.
+                revert(0x1c, 0x04)
+            }
+            // The top element is at index `n - 1`: `salt * slot + (n << 32)`.
+            value := tload(add(mul(_STACK_BASE_SALT, ptr.slot), shl(32, n)))
+            tstore(ptr.slot, sub(n, 1)) // Decrement the size.
+        }
+    }
+
+    /// @dev Clears the stack at `ptr`.
+    /// Note: Values are not zeroed out, but the size is reset to zero.
+    function clear(TBytes32Stack storage ptr) internal {
+        /// @solidity memory-safe-assembly
+        assembly {
+            tstore(ptr.slot, 0)
         }
     }
 

--- a/test/LibTransient.t.sol
+++ b/test/LibTransient.t.sol
@@ -366,6 +366,106 @@ contract LibTransientTest is SoladyTest {
         return LibTransient.tStack(stackSlot).pop();
     }
 
+    function testBytes32StackPushPop() public {
+        uint256 stackSlot = 123;
+        LibTransient.tBytes32Stack(stackSlot).push(bytes32(uint256(1)));
+        LibTransient.tBytes32Stack(stackSlot).push(bytes32(uint256(2)));
+        LibTransient.tBytes32Stack(stackSlot).push(bytes32(uint256(3)));
+        assertEq(LibTransient.tBytes32Stack(stackSlot).size(), 3);
+        assertEq(LibTransient.tBytes32Stack(stackSlot).top(), bytes32(uint256(3)));
+        assertEq(LibTransient.tBytes32Stack(stackSlot).top(0), bytes32(uint256(3)));
+        assertEq(LibTransient.tBytes32Stack(stackSlot).top(1), bytes32(uint256(2)));
+        assertEq(LibTransient.tBytes32Stack(stackSlot).top(2), bytes32(uint256(1)));
+        assertEq(LibTransient.tBytes32Stack(stackSlot).pop(), bytes32(uint256(3)));
+        assertEq(LibTransient.tBytes32Stack(stackSlot).pop(), bytes32(uint256(2)));
+        assertEq(LibTransient.tBytes32Stack(stackSlot).pop(), bytes32(uint256(1)));
+        assertEq(LibTransient.tBytes32Stack(stackSlot).size(), 0);
+    }
+
+    function testBytes32StackPushPop(uint256 stackSlot, bytes32[] memory values) public {
+        unchecked {
+            for (uint256 i; i < values.length; ++i) {
+                assertEq(LibTransient.tBytes32Stack(stackSlot).size(), i);
+                LibTransient.tBytes32Stack(stackSlot).push(values[i]);
+                assertEq(LibTransient.tBytes32Stack(stackSlot).top(), values[i]);
+            }
+            assertEq(LibTransient.tBytes32Stack(stackSlot).size(), values.length);
+            // Check `top(i)` from the top.
+            for (uint256 i; i < values.length; ++i) {
+                assertEq(
+                    LibTransient.tBytes32Stack(stackSlot).top(i), values[values.length - 1 - i]
+                );
+            }
+            // Pop everything in reverse order.
+            for (uint256 i = values.length; i != 0;) {
+                --i;
+                assertEq(LibTransient.tBytes32Stack(stackSlot).size(), i + 1);
+                assertEq(LibTransient.tBytes32Stack(stackSlot).pop(), values[i]);
+            }
+            assertEq(LibTransient.tBytes32Stack(stackSlot).size(), 0);
+        }
+    }
+
+    function testBytes32StackClear(bytes32 stackSlot) public {
+        uint256 n = _randomUniform() & 7;
+        for (uint256 i; i < n; ++i) {
+            LibTransient.tBytes32Stack(stackSlot).push(keccak256(abi.encode(i)));
+        }
+        assertEq(LibTransient.tBytes32Stack(stackSlot).size(), n);
+        LibTransient.tBytes32Stack(stackSlot).clear();
+        assertEq(LibTransient.tBytes32Stack(stackSlot).size(), 0);
+        // Reusing after clear starts fresh.
+        for (uint256 i; i < n; ++i) {
+            assertEq(LibTransient.tBytes32Stack(stackSlot).size(), i);
+            bytes32 x = keccak256(abi.encode("v", i));
+            LibTransient.tBytes32Stack(stackSlot).push(x);
+            assertEq(LibTransient.tBytes32Stack(stackSlot).top(), x);
+        }
+    }
+
+    function testBytes32StackNoCollision(uint256 aSlot, uint256 bSlot) public {
+        if (aSlot == bSlot) bSlot = aSlot ^ 1;
+        uint256 n = 8;
+        for (uint256 i; i < n; ++i) {
+            LibTransient.tBytes32Stack(aSlot).push(keccak256(abi.encode("a", i)));
+            LibTransient.tBytes32Stack(bSlot).push(keccak256(abi.encode("b", i)));
+        }
+        for (uint256 i = n; i != 0;) {
+            --i;
+            assertEq(LibTransient.tBytes32Stack(aSlot).pop(), keccak256(abi.encode("a", i)));
+            assertEq(LibTransient.tBytes32Stack(bSlot).pop(), keccak256(abi.encode("b", i)));
+        }
+    }
+
+    function testEmptyBytes32StackTopReverts() public {
+        vm.expectRevert(LibTransient.StackIsEmpty.selector);
+        this.bytes32StackTop(0);
+    }
+
+    function testEmptyBytes32StackTopIndexReverts() public {
+        uint256 stackSlot;
+        LibTransient.tBytes32Stack(stackSlot).push(bytes32(uint256(1)));
+        vm.expectRevert(LibTransient.StackIsEmpty.selector);
+        this.bytes32StackTop(0, 1);
+    }
+
+    function testEmptyBytes32StackPopReverts() public {
+        vm.expectRevert(LibTransient.StackIsEmpty.selector);
+        this.bytes32StackPop(0);
+    }
+
+    function bytes32StackTop(uint256 stackSlot) public view returns (bytes32) {
+        return LibTransient.tBytes32Stack(stackSlot).top();
+    }
+
+    function bytes32StackTop(uint256 stackSlot, uint256 i) public view returns (bytes32) {
+        return LibTransient.tBytes32Stack(stackSlot).top(i);
+    }
+
+    function bytes32StackPop(uint256 stackSlot) public returns (bytes32) {
+        return LibTransient.tBytes32Stack(stackSlot).pop();
+    }
+
     function testRegistry(bytes32 key, bytes memory value) public {
         _etchTransientRegistry();
         if (_randomChance(2)) {


### PR DESCRIPTION
Closes #1185

Adds `TBytes32Stack`  a transient storage value stack for `bytes32`.

Unlike `TStack` (which generates typed pointers), this stores values directly.

## API
- `tBytes32Stack(bytes32/uint256)` → pointer
- `push(ptr, bytes32)`  store value
- `pop(ptr)` → remove and return top (reverts if empty)
- `top(ptr)` → peek top (reverts if empty)  
- `top(ptr, uint256 i)` → i-th from top, 0=top
- `size(ptr)` → element count
- `clear(ptr)` → reset stack

## Design
- Pure assembly, TSTORE/TLOAD
- Reuses existing `StackIsEmpty` error
- Element stride: `_STACK_BASE_SALT * slot + ((i+1) << 32)`
- clear() zeroes size only — push always writes before read, no stale values

## Tests
7 new tests  concrete, fuzz, collision, 3 revert cases
Run: `FOUNDRY_PROFILE=post_osaka forge test --match-path test/LibTransient.t.sol`
29 passed, 0 failed